### PR TITLE
fix(skills): align SKILL.md name with directory for 2 skills

### DIFF
--- a/skills/pulse-dashboard/SKILL.md
+++ b/skills/pulse-dashboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bmad-pulse-dashboard
+name: pulse-dashboard
 description: 'Generate a cumulative PULSE efficiency dashboard with longitudinal metrics, trends, and insights. Use to visualize performance over time.'
 standalone: true
 main_config: '{project-root}/_bmad/config.yaml'

--- a/skills/pulse-track-start/SKILL.md
+++ b/skills/pulse-track-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bmad-pulse-track-start
+name: pulse-track-start
 description: 'Record the start of story implementation for PULSE efficiency metrics. Use when starting /bmad-dev-story or manually to register a start.'
 standalone: true
 main_config: '{project-root}/_bmad/config.yaml'


### PR DESCRIPTION
## Summary
- Remove stray `bmad-` prefix from `name:` frontmatter in `pulse-dashboard` and `pulse-track-start`
- Installer skips skills when frontmatter `name` does not match directory name, causing these two to fail silently during setup
- Aligns with convention already used by the other three skills (`pulse-setup`, `pulse-track-done`, `pulse-agent-levi`)

## Repro
During `bmad install` as custom module on v6.3.0:
```
Error: SKILL.md name "bmad-pulse-dashboard" does not match directory name "pulse-dashboard" — skipping
Error: SKILL.md name "bmad-pulse-track-start" does not match directory name "pulse-track-start" — skipping
```

## Test plan
- [x] Reinstall PULSE as custom module in a BMAD project — no skip errors
- [x] Verify `/pulse-dashboard` and `/pulse-track-start` skills are discoverable after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)