### PR TITLE
release: sync develop into main

### DIFF
--- a/skills/pulse-dashboard/SKILL.md
+++ b/skills/pulse-dashboard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bmad-pulse-dashboard
+name: pulse-dashboard
 description: 'Generate a cumulative PULSE efficiency dashboard with longitudinal metrics, trends, and insights. Use to visualize performance over time.'
 standalone: true
 main_config: '{project-root}/_bmad/config.yaml'

--- a/skills/pulse-track-start/SKILL.md
+++ b/skills/pulse-track-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bmad-pulse-track-start
+name: pulse-track-start
 description: 'Record the start of story implementation for PULSE efficiency metrics. Use when starting /bmad-dev-story or manually to register a start.'
 standalone: true
 main_config: '{project-root}/_bmad/config.yaml'


### PR DESCRIPTION
## Summary
- Sync `develop` into `main` to trigger release-please
- Includes #6 — fix SKILL.md name mismatch for `pulse-dashboard` and `pulse-track-start`

## Test plan
- [x] After merge, release-please opens a release PR in `main` with CHANGELOG + version bump
- [x] Installing PULSE as custom module no longer skips the two skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)