### PR TITLE
fix(ci): bump patch for fix commits in pre-major releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "simple",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         "skills/pulse-setup/assets/module.yaml",
         ".claude-plugin/marketplace.json"


### PR DESCRIPTION
## Summary
- Flip `bump-patch-for-minor-pre-major` from `false` to `true` in `release-please-config.json`
- During 0.x (pre-major), `fix:` commits were being bumped to minor. Now they bump patch, as expected
- `feat:` commits keep bumping minor

## Before / After (assuming current 0.3.0)
| Commit type | Before | After |
|---|---|---|
| `fix:` | 0.3.0 → 0.4.0 | 0.3.0 → 0.3.1 |
| `feat:` | 0.3.0 → 0.4.0 | 0.3.0 → 0.4.0 |
| `feat!:` (breaking) | 0.3.0 → 0.4.0 | 0.3.0 → 0.4.0 |

## Test plan
- [ ] Merge this PR to develop
- [ ] Merge PR #8 (release 0.3.0) first to close the current cycle
- [ ] Sync develop → main; next `fix:` commit should bump to 0.3.1, not 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)