### PR TITLE
docs(readme): clarify v1.0 roadmap as a pitch to BMAD core

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ That number isn't the ceiling. It's a data point. PULSE exists so your team can 
 - **v0.5** — Period-navigable dashboard (week / sprint / quarter views, side-by-side comparison)
 - **v0.6** — Per-developer and per-agent leverage breakdowns, with privacy guards on by default
 - **v0.7** — Slack and Linear digests so signals reach leadership without a meeting
-- **v1.0** — Native adoption into BMAD core, pending discussion with maintainers
+- **v1.0** — Pitch to BMAD core for native adoption.
 
 ---
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -188,7 +188,7 @@ Esse número não é o teto. É um ponto de dado. PULSE existe para que seu time
 - **v0.5** — Dashboard navegável por período (visões semana / sprint / trimestre, comparação lado a lado)
 - **v0.6** — Quebras de alavancagem por desenvolvedor e por agente, com guards de privacidade ativos por padrão
 - **v0.7** — Digests no Slack e Linear para sinais chegarem à liderança sem reunião
-- **v1.0** — Adoção nativa no BMAD core, em discussão com mantenedores
+- **v1.0** — Proposta à equipe principal do BMAD para adoção nativa
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces \"pending discussion with maintainers\" with the more direct \"Pitch to BMAD core for native adoption.\" Aligns wording across English and Brazilian Portuguese READMEs.

## Test plan

- [x] README.md updated
- [x] README.pt-BR.md updated
- [ ] Tests pass (waiting CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)