### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: 🐛 Bug Report
+description: Report a defect in PULSE — something doesn't behave as documented.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the sections below — the more reproducible the bug, the faster the fix.
+
+        **Security issue?** Stop here and read [SECURITY.md](https://github.com/nidelson/bmad-module-pulse/blob/main/SECURITY.md) for the private disclosure process.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the behavior you observed.
+      placeholder: When I run `/bmad-pulse-dashboard`, the leverage column shows 0.0x for all stories…
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: Describe the behavior you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to trigger the bug. The more concrete, the better.
+      placeholder: |
+        1. Run `/bmad-pulse-setup` on a fresh BMAD project
+        2. Run `/bmad-pulse-track-start STORY-123`
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: pulse-version
+    attributes:
+      label: PULSE version
+      description: From `CHANGELOG.md` or `git tag`.
+      placeholder: e.g. 0.4.1
+    validations:
+      required: true
+
+  - type: input
+    id: bmad-version
+    attributes:
+      label: BMAD-METHOD version
+      description: From your project's BMAD installation.
+      placeholder: e.g. 6.6.0
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: e.g. 3.12.7
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g. macOS 14.5 / Ubuntu 22.04 / Windows 11 (WSL)
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant logs, stack traces, or output. Use code fences.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help — config snippets, screenshots, related issues.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and confirmed this is not a duplicate
+          required: true
+        - label: I am running a [supported version](https://github.com/nidelson/bmad-module-pulse/blob/main/SECURITY.md#supported-versions)
+          required: true
+        - label: This is not a security issue (those go through SECURITY.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Security vulnerability
+    url: https://github.com/nidelson/bmad-module-pulse/blob/main/SECURITY.md
+    about: Do NOT file public issues for security bugs. See SECURITY.md for the private disclosure process.
+  - name: 💬 General question or discussion
+    url: https://github.com/nidelson/bmad-module-pulse/discussions
+    about: For open-ended questions, ideas, or showing how you use PULSE.
+  - name: 📚 BMAD-METHOD itself
+    url: https://github.com/bmad-code-org/BMAD-METHOD/issues
+    about: PULSE is a BMAD module. For BMAD core issues, use the upstream tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: ✨ Feature Request
+description: Suggest a new feature or improvement for PULSE.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the problem first, then the proposed solution. Issues that lead with the *problem* (not the solution) are usually easier to triage.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the user-facing pain point. What does PULSE not do today that you wish it did?
+      placeholder: When I have 50+ stories in the dashboard, the breakdown table becomes unreadable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+      description: How would you solve it? Sketch the desired behavior, config knobs, or output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you think about? Why didn't they fit?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Estimated scope
+      description: Your best guess at the size of change.
+      options:
+        - Small (< 1 day, single skill)
+        - Medium (config knob + skill changes)
+        - Large (cross-skill, schema or breaking change)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related issues or discussions
+      description: Link any relevant existing issues, PRs, or external discussions.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and confirmed this is not a duplicate
+          required: true
+        - label: This aligns with PULSE's scope (BMAD-native observability — not a general analytics platform)
+          required: true
+        - label: I'm willing to discuss tradeoffs and iterate on the proposal
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for the contribution! Fill in the sections below.
+For minor changes (typos, small docs tweaks), feel free to delete sections that don't apply.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What does this PR do and why? -->
+
+## Type of change
+
+<!-- Check one. The Conventional Commit prefix on your commit(s) should match. -->
+
+- [ ] `feat:` — New feature
+- [ ] `fix:` — Bug fix
+- [ ] `chore:` — Tooling, deps, repo hygiene
+- [ ] `docs:` — Documentation only
+- [ ] `refactor:` — Internal restructure (no behavior change)
+- [ ] `perf:` — Performance improvement
+- [ ] `test:` — Adding or updating tests
+- [ ] Breaking change (`feat!:` or `BREAKING CHANGE:` in commit body)
+
+## Related issue
+
+<!-- e.g. "Closes #42" or "Refs #42" — leave blank if no issue. -->
+
+## How was this tested?
+
+<!-- Describe the test approach. New unit tests? Integration tests? Manual verification? -->
+
+- [ ] `python -m pytest tests/ -v` passes locally
+- [ ] New behavior is covered by tests (or N/A — explain why)
+- [ ] Manual verification in a consumer BMAD project (if relevant)
+
+## Checklist
+
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] Documentation updated (README, MIGRATION, examples) where relevant
+- [ ] Bilingual docs synced — `*.pt-BR.md` mirrors updated when English versions change
+- [ ] No secrets, API keys, or proprietary data in the diff
+- [ ] CHANGELOG entry NOT manually edited (release-please handles it)
+
+## Screenshots / output (optional)
+
+<!-- For dashboard, CLI output, or UI changes — paste a sample. -->
+
+## Additional notes
+
+<!-- Anything reviewers should know? Tradeoffs, follow-up tasks, things you're unsure about. -->


### PR DESCRIPTION
## Summary

Closes the last 2 GitHub Community Standards gaps. Templates are project-tailored, not generic.

### Issue templates (YAML form syntax — guided UX)

- **bug_report.yml** — required version fields (PULSE, BMAD, Python, OS), structured repro steps, logs section, pre-submission checklist
- **feature_request.yml** — problem-first format, scope dropdown (S/M/L), alignment-with-PULSE-scope check
- **config.yml** — disables blank issues; adds contact links for:
  - Security disclosure (→ SECURITY.md)
  - Discussions (general questions)
  - Upstream BMAD-METHOD tracker

### Pull request template

- Conventional Commit type checklist (drives release-please bumps)
- Test plan (pytest local + manual verification when relevant)
- Bilingual docs sync reminder (`*.pt-BR.md` mirrors)
- Security/secrets check
- "CHANGELOG NOT manually edited" reminder (release-please owns it)

All wording aligns with [CONTRIBUTING.md](https://github.com/nidelson/bmad-module-pulse/blob/main/CONTRIBUTING.md) and [SECURITY.md](https://github.com/nidelson/bmad-module-pulse/blob/main/SECURITY.md).

## Test plan

- [x] Issue templates render in the issue creation flow (YAML form spec)
- [x] PR template auto-populates new PR descriptions
- [x] config.yml disables blank issues + shows contact links
- [ ] pytest passes (no code change, should be trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)