### PR TITLE
ci(release-please): allow PAT for triggering downstream workflows

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,3 +19,4 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+          token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_PAT` when set so bot-created release PRs trigger required status checks
- Falls back to `GITHUB_TOKEN` if secret missing — preserves current behavior

## Context
release-please bot creates PRs with `GITHUB_TOKEN` which by design does not trigger workflows. Required check `pytest` never runs → release PR blocked by branch protection. v0.4.2 needed manual empty commit to unblock.

## Test plan
- [ ] Merge this PR
- [ ] Create `RELEASE_PLEASE_PAT` secret (fine-grained PAT, scoped to repo: Contents RW, Pull requests RW, Workflows RW)
- [ ] Verify next release PR auto-triggers Tests workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)