### PR TITLE
feat(track-done): structured halts with approval_wait subtraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,32 @@ PULSE instruments three points in the BMAD story lifecycle:
 - **Alert** — halt detection when a story stalls beyond its estimate.
 - **Coach** — Levi reads the metrics and pinpoints bottlenecks in plain English.
 
+### Halt categories — separating dev work from wait time
+
+Wall-clock time can be inflated by latencies that aren't dev work. PULSE captures these as structured halts in `process_health.halts` and subtracts them from `actual_hours` so leverage reflects real engineering effort.
+
+| `kind`           | What it represents                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| `approval_wait`  | Paused waiting for explicit user approval (admin merge, scope expansion, irreversible action).      |
+| `incident`       | External infra outage, GitHub down, dependency unavailable.                                         |
+| `external_pause` | User-initiated break that should not count as dev work.                                             |
+| `other`          | Anything else — document with `note`.                                                               |
+
+**Threshold:** only document halts longer than 2 minutes. Below that is conversational latency, not a halt.
+
+**Pre-approved batch decisions:** when a prior story granted durable approval covering the current one (e.g., "Admin merge applies to the entire epic-setup batch"), set `pre_approved_batch: true` on the halt entry. PULSE reports it but does not subtract — this rewards batch-decision behavior, which is operationally correct for human-in-the-loop AI workflows.
+
+```yaml
+process_health:
+  halts:
+    - kind: approval_wait
+      context: admin_merge_decision
+      duration_min: 7
+      pre_approved_batch: false
+```
+
+Why it matters: AI dev rate >> human review rate. Without this, every "AI does 5min of work, human takes 5min to approve" cycle gets logged as 0.5x leverage instead of the real number.
+
 ---
 
 ## Configuration

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -158,6 +158,32 @@ PULSE instrumenta três pontos no ciclo de vida da story BMAD:
 - **Alert** — detecção de halt quando uma story trava além da estimativa.
 - **Coach** — Levi lê as métricas e aponta gargalos em linguagem clara.
 
+### Categorias de halt — separando trabalho de IA de tempo de espera
+
+Wall-clock pode ser inflado por latências que não são trabalho de dev. PULSE captura essas latências como halts estruturados em `process_health.halts` e subtrai do `actual_hours` para que a alavancagem reflita esforço real de engenharia.
+
+| `kind`           | O que representa                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `approval_wait`  | Pausa aguardando aprovação explícita do usuário (admin merge, expansão de escopo, ação irreversível).  |
+| `incident`       | Indisponibilidade externa, GitHub fora, dependência indisponível.                                      |
+| `external_pause` | Pausa iniciada pelo usuário que não deve contar como trabalho de dev.                                  |
+| `other`          | Qualquer outro caso — documentar com `note`.                                                           |
+
+**Threshold:** documentar apenas halts maiores que 2 minutos. Abaixo disso é latência conversacional, não halt.
+
+**Decisões batch pré-aprovadas:** quando uma story anterior concedeu aprovação durável que cobre a atual (ex.: "Admin merge vale para todo o batch epic-setup"), marque `pre_approved_batch: true` na entrada do halt. PULSE registra mas não subtrai — isso premia o comportamento de batch-decision, operacionalmente correto para workflows human-in-the-loop com IA.
+
+```yaml
+process_health:
+  halts:
+    - kind: approval_wait
+      context: admin_merge_decision
+      duration_min: 7
+      pre_approved_batch: false
+```
+
+Por que importa: taxa de dev de IA >> taxa de review humano. Sem isso, cada ciclo "IA faz 5min de trabalho, humano leva 5min para aprovar" é logado como 0.5x de alavancagem em vez do número real.
+
 ---
 
 ## Configuração

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -47,6 +47,17 @@ Load the `pulse` section from `{main_config}` and resolve all module variables:
    - Total estimated hours vs total actual hours
    - First-pass rate
    - Leverage by category (use `{pulse_dev_categories}`)
+   - **Halt aggregations** (read `process_health.halts` from each story; the field has three valid shapes — handle all without crashing):
+     - **Shape A** (integer): treat as opaque count, skip duration math.
+     - **Shape B** (list of objects): structured — read `kind`, `context`, `duration_min`, `pre_approved_batch`.
+     - **Shape C** (list of plain strings, legacy pre-0.5.0): infer `kind` from prefix when possible (`approval_wait_*` → `approval_wait`); `duration_min` is unknown — count as halt but exclude from minute aggregations.
+     - Aggregations:
+       - `total_halts` — sum across all stories (integers + list lengths regardless of shape)
+       - `total_approval_wait_count` — count of entries where `kind == approval_wait` (Shape B explicit, Shape C inferred via prefix)
+       - `total_approval_wait_minutes` — sum of `duration_min` for Shape B entries with `kind == approval_wait` and `pre_approved_batch != true` (Shape C contributes 0 — duration unknown)
+       - `total_pre_approved_batch_count` — count of `approval_wait` entries with `pre_approved_batch: true` (Shape B only)
+       - `legacy_halt_string_count` — count of Shape C entries encountered (used to surface migration hint in insights)
+       - `stories_with_approval_wait` — list of `(story_id, total_minutes)` pairs for the breakdown table (entries with unknown minutes show as `?min`)
 
 ### Step 2: Generate Dashboard
 
@@ -103,6 +114,32 @@ Based on avg leverage of {avg}x:
 - 80h estimated → ~{80/avg}h actual
 <!-- END CONDITIONAL capacity_forecast -->
 
+<!-- CONDITIONAL: include only if total_approval_wait_count > 0 OR total_pre_approved_batch_count > 0 -->
+## ⏸ Approval-Wait Halts
+
+| Metric                                  | Value                              |
+| --------------------------------------- | ---------------------------------- |
+| Approval-wait halts (subtracted)        | {total_approval_wait_count}        |
+| Total approval-wait time subtracted     | {total_approval_wait_minutes}min   |
+| Pre-approved batch decisions (skipped)  | {total_pre_approved_batch_count}   |
+
+{if stories_with_approval_wait}
+**By story:**
+
+| Story | Approval-wait minutes |
+| ----- | --------------------- |
+{for each (story_id, minutes) in stories_with_approval_wait}
+| {story_id} | {minutes}min |
+{end}
+{end}
+
+> Approval-wait halts measure governance latency (human-in-the-loop decisions) and are subtracted from `actual_hours` so leverage reflects real dev work, not wait time. `pre_approved_batch` flags durable decisions that legitimately remove latency on subsequent stories — these are reported but not subtracted.
+
+{if legacy_halt_string_count > 0}
+> ⚠ {legacy_halt_string_count} legacy halt entries (plain strings, pre-0.5.0 format) were detected. Their durations are not machine-readable and were excluded from minute totals. Migrate these entries to the structured shape (with `kind`, `context`, `duration_min`) for accurate leverage on historical stories.
+{end}
+<!-- END CONDITIONAL approval_wait -->
+
 ## 💡 Process Insights
 
 {insights generated based on the data}
@@ -150,3 +187,5 @@ The detail level of the summary must respect `pulse_levi_verbosity`.
 - The leverage trend section must only be included if `pulse_include_trend_chart == yes`
 - The capacity forecast section must only be included if `pulse_include_capacity_forecast == yes`
 - The categories table must use the categories defined in `pulse_dev_categories` (not hardcoded categories)
+- The Approval-Wait Halts section must only be rendered when `total_approval_wait_count + total_pre_approved_batch_count > 0`
+- When reading `process_health.halts`, accept both shapes (integer count and structured list) and degrade gracefully — never crash on legacy data

--- a/skills/bmad-pulse-track-done/workflow.md
+++ b/skills/bmad-pulse-track-done/workflow.md
@@ -56,6 +56,24 @@ Load the config from the `pulse` section of `{main_config}` and resolve all modu
 2. Add the `end_ts` field with the current ISO 8601 timestamp
 3. Ask the user: "How many review cycles were needed?" → `review_cycles`
 4. Ask (optional): "Effective AI working time? (leave empty to use wall-clock)" → `effective_hours`
+5. Ask about halts >2min (skip if `effective_hours` was provided — wall-clock is being overridden):
+
+   **Prompt:** "Were there any halts >2min during execution?" — examples:
+   - `approval_wait` — paused waiting for explicit user approval (admin merge, scope expansion, irreversible action)
+   - `incident` — external infra outage, GitHub down, dependency unavailable
+   - `external_pause` — user-initiated break that should not count as dev work
+   - `other` — anything else (document with note)
+
+   For each halt, capture:
+   - `kind` (enum above)
+   - `context` (short identifier, e.g., `admin_merge_decision`, `github_outage`)
+   - `duration_min` (integer minutes, must be >2)
+   - `pre_approved_batch` (boolean, default false — set `true` if a prior story granted durable approval covering this case, e.g., "admin merge pre-approved across the entire epic-setup batch")
+   - `note` (optional human context)
+
+   **Threshold rule:** only document halts with `duration_min > 2`. Below that is conversational latency, not a halt.
+
+   **Pre-approved batch rule:** if a prior story in the same batch already captured the approval decision and the user confirmed it applies durably (e.g., "Admin merge for entire epic-setup batch"), set `pre_approved_batch: true` on subsequent halt entries OR omit the halt entirely with a comment explaining the durable decision. This rewards batch-decision behavior, which is operationally correct for human-in-the-loop AI workflows.
 
 ### Step 3: Calculate Metrics
 
@@ -88,13 +106,34 @@ estimated_hours = value recorded directly in hours
 
 ```text
 elapsed_minutes = (end_ts - start_ts) in minutes
-actual_hours = effective_hours ?? (elapsed_minutes / 60)
+
+# Halt subtraction (only when halts is a structured list, not a legacy integer):
+halt_minutes = sum(
+  h.duration_min for h in halts
+  if isinstance(halts, list)
+  and h.duration_min
+  and not h.pre_approved_batch
+)
+
+actual_hours = effective_hours ?? max(0.01, (elapsed_minutes - halt_minutes) / 60)
 leverage_ratio = estimated_hours / actual_hours
 first_pass = review_cycles == 1
 ```
 
+**Halt subtraction rules:**
+
+- If `effective_hours` is provided, `halt_minutes` is ignored (user already supplied the corrected value).
+- If `halts` is a legacy integer (e.g., `halts: 0`), no subtraction — the field carries no duration data.
+- If `halts` is a structured list, each entry with `duration_min` and `pre_approved_batch != true` contributes to `halt_minutes`.
+- If `halts` is a list of plain strings (legacy free-form shape, see Shape C below), no subtraction — duration data lives only in YAML comments and is not machine-readable. Emit a warning suggesting migration to Shape B.
+- Floor `actual_hours` at 0.01h to avoid divide-by-zero in `leverage_ratio`.
+- Document the subtraction inline with a YAML comment on `actual_hours` so the math is traceable, e.g.:
+  ```yaml
+  actual_hours: 0.65  # 46min wall-clock - 7min approval_wait_admin_merge_decision
+  ```
+
 1. Add the `review_cycles` field with the value provided by the user
-2. Add the `actual_hours` field with the calculated value
+2. Add the `actual_hours` field with the calculated value (with traceability comment when halts were subtracted)
 3. Add the `leverage_ratio` field with the calculated value (1 decimal)
 4. Add the `first_pass` field as a boolean
 
@@ -117,6 +156,7 @@ Display in the terminal:
    📋 Process Health
    Flow: {flow_check}
    HALTs: {halt_count} | Underused skills: {unused_skills_list}
+   {if any halt.kind == approval_wait}Approval-wait: {n} halt(s), {total_min}min total ({pre_approved_count} pre-approved batch){end}
 
    💡 {process_insight}
 ```
@@ -136,13 +176,16 @@ The verification level is determined by `pulse_process_health_checks`:
    - If any step was skipped (e.g. directly from backlog to done): "⚠ Steps skipped"
 
 2. **HALTs** (respect `pulse_alert_on_halt`):
-   - Locate the story file in the configured implementation artifacts folder
-   - Read the "Dev Agent Record" section of the story file
-   - Count occurrences of the word "HALT"
-   - If `pulse_alert_on_halt` is `yes`: display an alert if halt_count > 0
+   - Combine two sources:
+     - **Story-file HALTs:** locate the story file in the configured implementation artifacts folder, read the "Dev Agent Record" section, count occurrences of the word "HALT".
+     - **Captured halts:** the structured list collected in Step 2 (if `halts` is a list, count its length; if it is a legacy integer, use that integer directly).
+   - `halt_count = max(story_file_halts, captured_halts_count)` — captured halts dominate when they exist (they carry duration), but a story-file-only HALT still surfaces in the count.
+   - If `pulse_alert_on_halt` is `yes`: display an alert if `halt_count > 0`
    - If `pulse_alert_on_halt` is `warn`: display as an informational warning
    - If `pulse_alert_on_halt` is `no`: record internally but do not display
    - If 0: display "0"
+   - When the captured list contains any `kind: approval_wait` entries, surface them separately in the card:
+     `Approval-wait: {N} halt(s), {total_min}min total ({pre_approved_count} pre-approved batch)`
 
 3. **Underused skills** (only if `pulse_alert_unused_skills` is `yes`):
    - If `category` is "fullstack" or "backend":
@@ -159,15 +202,48 @@ The verification level is determined by `pulse_process_health_checks`:
    - If `pulse_levi_coaching_mode` is `metrics-only`: display data only, no suggestions
 
 5. **Persistence:**
-   - Add the `process_health` field to the story entry in `pulse_metrics`:
+   - Add the `process_health` field to the story entry in `pulse_metrics`.
+   - `halts` accepts two shapes (writers should prefer the structured list whenever halts were observed; the integer form remains valid for "no halts captured"):
 
-```yaml
-process_health:
-  flow_complete: true
-  halts: 0
-  unused_skills: ['tea:automate']
-  insight: 'Consider tea:automate for fullstack stories'
-```
+   **Shape A — no halts captured (legacy / shorthand):**
+
+   ```yaml
+   process_health:
+     flow_complete: true
+     halts: 0
+     unused_skills: ['tea:automate']
+     insight: 'Consider tea:automate for fullstack stories'
+   ```
+
+   **Shape B — structured list (required when halts >2min were captured):**
+
+   ```yaml
+   process_health:
+     flow_complete: true
+     halts:
+       - kind: approval_wait               # approval_wait | incident | external_pause | other
+         context: admin_merge_decision     # short identifier
+         duration_min: 7                   # integer minutes (>2)
+         pre_approved_batch: false         # true skips actual_hours subtraction
+         note: 'CI blocked by GH incident, waited for user merge override decision'  # optional
+       - kind: incident
+         context: github_outage
+         duration_min: 360
+     unused_skills: []
+     insight: 'Approval-wait dominated this story — consider batching the next governance call.'
+   ```
+
+   **Shape C — legacy free-form strings (read-only fallback for pre-0.5.0 data):**
+
+   ```yaml
+   process_health:
+     halts:
+       - approval_wait_admin_merge_decision  # ~7min — duration in comment, not machine-readable
+   ```
+
+   - Readers MUST handle all three shapes. Treat `halts: 0` as "empty list" semantically. Treat `halts: <int N>` as "N opaque halts, no duration data." Treat a string entry as "1 opaque halt, kind/context inferred from string prefix when possible (e.g., `approval_wait_*` → `kind: approval_wait`), `duration_min` unknown — do NOT subtract from `actual_hours`."
+   - Writers MUST NOT emit Shape C. Always write Shape A (no halts) or Shape B (structured). Shape C exists only to keep dashboards from breaking on historical data written before v0.5.0.
+   - When Shape C is detected, surface a one-line warning in the track-done card: `⚠ Legacy halt format detected — consider migrating to structured shape for accurate leverage.`
 
 ### Step 5: Compare with History
 


### PR DESCRIPTION
## Summary

Closes #18.

Adds `approval_wait` as a first-class halt category in `process_health.halts` so PULSE leverage reflects real dev work, not human-in-the-loop governance latency.

## Schema

`process_health.halts` now accepts three shapes (readers handle all; writers emit A or B):

- **Shape A** — `halts: 0` (integer, legacy / no halts captured)
- **Shape B** — list of objects (canonical):
  ```yaml
  halts:
    - kind: approval_wait              # approval_wait | incident | external_pause | other
      context: admin_merge_decision
      duration_min: 7
      pre_approved_batch: false
      note: "optional"
  ```
- **Shape C** — list of plain strings (read-only fallback for pre-0.5.0 data; `duration_min` not machine-readable, no subtraction applied, migration hint surfaced)

## Behavior

- **Threshold**: only halts >2min are captured. Below that = conversational latency.
- **Subtraction**: `actual_hours = max(0.01, (elapsed_min - sum(non-pre-approved halt minutes)) / 60)` when `effective_hours` not provided.
- **Pre-approved batch**: `pre_approved_batch: true` skips subtraction (durable governance decisions are reported, not penalized).
- **Backward compat**: Shape A and Shape C keep working for historical data.

## Files

- `skills/bmad-pulse-track-done/workflow.md` — Step 2 prompt, Step 3 subtraction formula, Step 4 HALTs source-merge rule, Step 4.5 three-shape persistence spec.
- `skills/bmad-pulse-dashboard/workflow.md` — Step 1 halt aggregations, new conditional "Approval-Wait Halts" section with by-story breakdown and Shape C migration hint.
- `README.md` + `README.pt-BR.md` — new "Halt categories" subsection under Capabilities, with enum table, threshold rule, and YAML example.

## Tests

`pytest tests/ -q` → 31 passed (cross-file invariants, fixtures, golden parity, traffic snapshot — all green; no logic tests existed for halts since skills are LLM-driven workflow specs).

## Test plan

- [x] Run `/bmad-pulse-track-done <story>` on a story with a real >2min approval wait — confirm prompt fires, halt persists in Shape B, `actual_hours` is subtracted with traceability comment.
- [x] Run `/bmad-pulse-track-done` on a story with `pre_approved_batch` halt — confirm halt is recorded but not subtracted.
- [x] Run `/bmad-pulse-dashboard` against SIP `sprint-status.yaml` (which contains Shape C entries from SEC-0..SEC-4) — confirm dashboard renders without crashing, surfaces the Shape C migration hint, and excludes those minutes from totals.
- [x] Run `/bmad-pulse-dashboard` against fresh data with Shape B entries — confirm "Approval-Wait Halts" section appears with correct totals and by-story breakdown.