### PR TITLE
fix(setup): idempotent skill reconcile to self-heal updates over existing installs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,18 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
 
-      - name: Install dev dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-
       - name: Run tests
-        run: python -m pytest tests/ -v
+        run: uv run --group test python -m pytest tests/ -v
 
       - name: Verify golden snapshots match templates
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,12 @@ _bmad-output/
 __pycache__/
 *.pyc
 .pytest_cache/
+# Transient lockfile from `uv run --with ...` test invocations — the
+# project pins no runtime deps, so this is never an authoritative lock.
+uv.lock
+
+# Claude Code local harness config — machine-specific, never shared
+.claude/settings.local.json
 
 # Implementation plans — controller's working tool, not product artifact
 docs/plans/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,16 @@ Thanks for considering a contribution. PULSE is a BMAD-native observability modu
 ```bash
 git clone https://github.com/nidelson/bmad-module-pulse.git
 cd bmad-module-pulse
-python -m pip install --upgrade pip
-pip install -r requirements-dev.txt
 ```
+
+Test dependencies are declared as the `test` [PEP 735](https://peps.python.org/pep-0735/)
+dependency group in `pyproject.toml`. [`uv`](https://docs.astral.sh/uv/)
+resolves and runs them on demand — no manual install step.
 
 ### Run tests
 
 ```bash
-python -m pytest tests/ -v
+uv run --group test pytest tests/ -v
 ```
 
 The test suite includes both unit tests and integration tests (marked with `@pytest.mark.integration`) that spin up fake consumer projects to validate end-to-end skill behavior.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ PULSE is also the **first BMAD-native observability plugin** on the marketplace.
 npx bmad-method install --custom-source https://github.com/nidelson/bmad-module-pulse
 ```
 
+> **Production: pin a released version.** The command above tracks
+> `main` (the manifest records `version: main`), so every re-run pulls
+> whatever has since landed on `main` — non-deterministic across a team
+> and across CI. For production projects, pin an explicit released tag:
+>
+> ```bash
+> npx bmad-method install \
+>   --custom-source https://github.com/nidelson/bmad-module-pulse \
+>   --version v0.4.5
+> ```
+>
+> Bump the tag deliberately when you want a new version. Pick one from
+> the [releases](https://github.com/nidelson/bmad-module-pulse/releases).
+> Upgrading over an existing install self-heals automatically — see
+> [MIGRATION.md](docs/MIGRATION.md#upgrading-over-an-existing-install--automatic-self-heal).
+
 Then in your BMAD project:
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,7 +61,7 @@ PULSE is currently maintained by a single person, so response times are best-eff
 - Dashboard generation logic
 - Configuration and template handling (`customize.toml`, golden templates)
 - Any file or path manipulation performed by PULSE
-- Dependencies declared in `requirements-dev.txt` and `pyproject.toml`
+- Test dependencies declared in the `test` dependency group in `pyproject.toml`
 
 ### Out of scope
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -36,6 +36,21 @@ reconciles it in place; the JSON `notice` will ask you to run
 `/bmad-pulse-setup` once more so the current version executes. Re-run it
 once and you are converged.
 
+**Production tip — pin a released tag.** Installing with the bare
+`--custom-source` tracks `main` (`version: main` in the manifest), so
+every re-run pulls whatever has since landed there. For deterministic,
+team-reproducible installs, pin an explicit tag and bump it deliberately:
+
+```bash
+npx bmad-method install \
+  --custom-source https://github.com/nidelson/bmad-module-pulse \
+  --version v0.4.5
+```
+
+Reconcile still runs on every `/bmad-pulse-setup` and converges the
+deployed tree to whatever the cache holds — pinning just makes *what the
+cache holds* deterministic.
+
 Manual reconcile (e.g. for a bug report) — `--dry-run` previews without
 writing:
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -5,6 +5,47 @@ skip to the version you are migrating from.
 
 ---
 
+## Upgrading over an existing install — automatic self-heal
+
+This applies to **every** PULSE upgrade, not a specific version.
+
+The upstream BMAD installer performs an *additive* deploy when PULSE is
+already installed in a project: brand-new files are copied, but
+pre-existing files (`module.yaml`, `SKILL.md`, …) are **not** overwritten
+and renamed/removed skills are **not** pruned. Re-running
+`npx bmad-method install` over an existing install therefore leaves a
+mixed state frozen at the old version — new files present, old files
+stale, orphan folders lingering (issue #36).
+
+`bmad-pulse-setup` now self-heals this. Its first step,
+`reconcile-skills.py`, force-syncs every PULSE skill directory from the
+authoritative source (the freshly-fetched BMAD custom-module cache) and
+prunes orphaned renamed folders. It is idempotent (no-op when already in
+sync) and non-fatal on fresh installs.
+
+```bash
+# 1. Fetch the new PULSE version (refreshes the BMAD custom-module cache)
+npx bmad-method install --custom-source https://github.com/nidelson/bmad-module-pulse
+
+# 2. Re-run setup — reconcile converges the deployed tree automatically
+/bmad-pulse-setup
+```
+
+If the deployed `bmad-pulse-setup` skill itself was stale, the first run
+reconciles it in place; the JSON `notice` will ask you to run
+`/bmad-pulse-setup` once more so the current version executes. Re-run it
+once and you are converged.
+
+Manual reconcile (e.g. for a bug report) — `--dry-run` previews without
+writing:
+
+```bash
+python3 .claude/skills/bmad-pulse-setup/scripts/reconcile-skills.py \
+    --project-root . --dry-run
+```
+
+---
+
 ## v0.4.4 → v0.4.5 — Levi agent consolidation
 
 v0.4.5 consolidates the Levi agent into a single canonical skill folder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
+# The module ships no installable Python package — its scripts run via
+# `python3 script.py` inside consumer projects with zero runtime deps
+# (`dependencies = []` in each script header). The only Python deps in this
+# repo are for the test suite, declared here as a PEP 735 dependency group.
+# Run the suite with: `uv run --group test pytest`
+[dependency-groups]
+test = [
+    "pytest>=8.0",
+    "pyyaml>=6.0",
+    "tomlkit>=0.13",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,0 @@
-pytest>=8.0
-tomlkit>=0.13
-pyyaml>=6.0

--- a/skills/bmad-pulse-setup/SKILL.md
+++ b/skills/bmad-pulse-setup/SKILL.md
@@ -28,6 +28,38 @@ Both config scripts use an anti-zombie pattern — existing entries for this mod
 
 If the user provides arguments (e.g. `accept all defaults`, `--headless`, or inline values like `user name is BMad, I speak Swahili`), map any provided values to config keys, use defaults for the rest, and skip interactive prompting. Still display the full confirmation summary at the end.
 
+## Reconcile Installed Skills (Self-Heal)
+
+Run this **first**, before any other step. The upstream BMAD installer
+performs an *additive* deploy when PULSE is already installed: brand-new
+files are copied, but pre-existing files (`module.yaml`, `SKILL.md`, …) are
+never overwritten and renamed/removed skills are never pruned. Updating
+over an existing install therefore leaves a mixed state stuck at the old
+version (see issue #36). This step force-syncs every PULSE skill directory
+from the authoritative source (the freshly-fetched BMAD custom-module
+cache) and prunes orphaned renamed folders.
+
+```bash
+python3 ./scripts/reconcile-skills.py --project-root "{project-root}"
+```
+
+The script is idempotent — on an already-in-sync tree it writes nothing and
+reports `action: up_to_date`. It is non-fatal on fresh installs: when no
+source/cache is found it exits 0 with `action: skipped_no_source`, so
+continue normally. Exit codes: 0=success, 1=validation error, 2=runtime
+error. Surface any non-zero exit and stop.
+
+Inspect the JSON `action` field:
+
+- `up_to_date` / `skipped_no_source` — continue silently.
+- `reconciled` — report `from_version → to_version` to the user. If the
+  payload includes a `notice` saying `bmad-pulse-setup` was updated in
+  place, tell the user to re-run `/bmad-pulse-setup` once more so the
+  current version of this skill executes, then stop.
+
+Run `./scripts/reconcile-skills.py --help` for full usage (including
+`--source` and `--dry-run`).
+
 ## Collect Configuration
 
 Ask the user for values. Show defaults in brackets. Present all values together so the user can respond once with only the values they want to change (e.g. "change language to Swahili, rest are fine"). Never tell the user to "press enter" or "leave blank" — in a chat interface they must type something to respond.

--- a/skills/bmad-pulse-setup/scripts/reconcile-skills.py
+++ b/skills/bmad-pulse-setup/scripts/reconcile-skills.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Self-heal PULSE skills deployed in a consumer project.
+
+The upstream BMAD installer performs an *additive* deploy when a custom
+module is already installed: brand-new files are copied, but pre-existing
+files are never overwritten and renamed/removed skills are never pruned.
+The result is a mixed state where `module.yaml`/`SKILL.md` stay frozen at
+the previous version while newly-added files (e.g. customize.toml) are
+present — and orphan folders from renamed skills linger.
+
+This script reconciles the deployed skill tree against an authoritative
+source (the freshly-fetched BMAD custom-module cache, or an explicit
+`--source`). It force-syncs every PULSE skill directory and prunes known
+renamed/removed folders. It is idempotent: when the deployed tree already
+matches the source, it makes no writes and reports `up_to_date`.
+
+It is also safe on fresh installs: if no source can be located, it exits 0
+with `skipped_no_source` so the caller (bmad-pulse-setup) can continue.
+
+Exit codes: 0=success (including up_to_date / skipped_no_source),
+1=validation error, 2=runtime error.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# Folders shipped by a previous PULSE version that were renamed/removed and
+# must be pruned from the consumer project once their canonical replacement
+# is in place. Maps legacy folder name -> canonical folder name (both under
+# .claude/skills/). The legacy folder is removed only when the canonical
+# folder exists in the source skill set AND is deployed in the project, so a
+# partial-state install is never stranded without the replacement.
+LEGACY_SKILL_FOLDERS = {
+    "bmad-pulse-agent-levi": "bmad-agent-pulse",
+}
+
+DEFAULT_CACHE_ROOT = Path.home() / ".bmad" / "cache" / "custom-modules"
+
+_MODULE_VERSION_RE = re.compile(r"^\s*module_version:\s*([^\s#]+)", re.MULTILINE)
+_REPO_URL_RE = re.compile(r"^\s*repoUrl:\s*(\S+)\s*$")
+_MODULE_ITEM_RE = re.compile(r"^\s*-\s+name:\s*(\S+)\s*$")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Reconcile deployed PULSE skills against an authoritative source."
+    )
+    parser.add_argument(
+        "--project-root",
+        required=True,
+        help="Path to the consumer project root",
+    )
+    parser.add_argument(
+        "--source",
+        help="Path to a fresh PULSE source tree (a directory containing "
+        "skills/). When omitted, the BMAD custom-module cache is discovered "
+        "from {project-root}/_bmad/_config/manifest.yaml",
+    )
+    parser.add_argument(
+        "--cache-root",
+        help=f"Base dir for the BMAD custom-module cache "
+        f"(default: {DEFAULT_CACHE_ROOT})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the planned actions without writing anything",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed progress to stderr",
+    )
+    return parser.parse_args()
+
+
+def _fail(message: str, code: int = 1):
+    print(json.dumps({"status": "error", "error": message}, indent=2))
+    sys.exit(code)
+
+
+def read_module_version(module_yaml: Path):
+    """Return the module_version string from a module.yaml, or None."""
+    if not module_yaml.is_file():
+        return None
+    match = _MODULE_VERSION_RE.search(module_yaml.read_text())
+    return match.group(1).strip() if match else None
+
+
+def discover_source(project_root: Path, cache_root: Path, verbose: bool):
+    """Locate the BMAD custom-module cache for PULSE from the manifest.
+
+    Parses {project-root}/_bmad/_config/manifest.yaml without a YAML
+    dependency: finds the `- name: pulse` module item and reads its
+    `repoUrl`, then maps it to <cache-root>/<host>/<owner>/<repo>.
+
+    Returns the resolved source path, or None when discovery is not
+    possible (fresh install, no manifest, no cache on disk).
+    """
+    manifest = project_root / "_bmad" / "_config" / "manifest.yaml"
+    if not manifest.is_file():
+        if verbose:
+            print(f"No manifest at {manifest}", file=sys.stderr)
+        return None
+
+    repo_url = None
+    in_pulse = False
+    for line in manifest.read_text().splitlines():
+        item = _MODULE_ITEM_RE.match(line)
+        if item:
+            in_pulse = item.group(1) == "pulse"
+            continue
+        if in_pulse:
+            url = _REPO_URL_RE.match(line)
+            if url:
+                repo_url = url.group(1)
+                break
+    if not repo_url or repo_url == "null":
+        if verbose:
+            print("No pulse repoUrl in manifest", file=sys.stderr)
+        return None
+
+    # https://github.com/owner/repo(.git) -> github.com/owner/repo
+    stripped = re.sub(r"^[a-z]+://", "", repo_url)
+    stripped = re.sub(r"\.git$", "", stripped)
+    parts = [p for p in stripped.split("/") if p]
+    if len(parts) < 3:
+        if verbose:
+            print(f"Unparseable repoUrl: {repo_url}", file=sys.stderr)
+        return None
+
+    candidate = cache_root.joinpath(*parts)
+    if not (candidate / "skills").is_dir():
+        if verbose:
+            print(f"Cache not found at {candidate}", file=sys.stderr)
+        return None
+    return candidate
+
+
+def list_source_skills(source_skills: Path):
+    """Immediate subdirectories of source/skills that contain a SKILL.md."""
+    return sorted(
+        p.name
+        for p in source_skills.iterdir()
+        if p.is_dir() and (p / "SKILL.md").is_file()
+    )
+
+
+def _digest(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def sync_skill(src: Path, dst: Path, dry_run: bool):
+    """Mirror src -> dst. Returns (written, deleted) file path lists.
+
+    Only files whose content differs are written; files present in dst but
+    absent in src are deleted (prune-within). This keeps the operation a
+    no-op when the tree already matches, which makes the script idempotent.
+    """
+    written = []
+    deleted = []
+
+    src_files = {
+        p.relative_to(src) for p in src.rglob("*") if p.is_file()
+    }
+    dst_files = (
+        {p.relative_to(dst) for p in dst.rglob("*") if p.is_file()}
+        if dst.exists()
+        else set()
+    )
+
+    for rel in sorted(src_files):
+        s = src / rel
+        d = dst / rel
+        if d.is_file() and _digest(s) == _digest(d):
+            continue
+        written.append(str(rel))
+        if dry_run:
+            continue
+        d.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(s, d)
+
+    for rel in sorted(dst_files - src_files):
+        deleted.append(str(rel))
+        if dry_run:
+            continue
+        (dst / rel).unlink()
+        # Drop now-empty directories left behind by the prune.
+        parent = (dst / rel).parent
+        while parent != dst and parent.is_dir() and not any(parent.iterdir()):
+            parent.rmdir()
+            parent = parent.parent
+
+    return written, deleted
+
+
+def prune_legacy_folders(skills_dir: Path, source_skills: list, dry_run: bool):
+    """Remove renamed/removed legacy skill folders from the project.
+
+    A legacy folder is removed only when its canonical replacement is part
+    of the source skill set (so we know the rename actually happened in this
+    version) AND the canonical folder is deployed in the project (so we
+    never strand the project without the replacement).
+    """
+    removed = []
+    for legacy, canonical in LEGACY_SKILL_FOLDERS.items():
+        legacy_dir = skills_dir / legacy
+        if not legacy_dir.is_dir():
+            continue
+        if canonical not in source_skills:
+            continue
+        if not (skills_dir / canonical).is_dir():
+            continue
+        removed.append(legacy)
+        if not dry_run:
+            shutil.rmtree(legacy_dir)
+    return removed
+
+
+def main():
+    args = parse_args()
+
+    project_root = Path(args.project_root)
+    if not project_root.is_dir():
+        _fail(f"--project-root does not exist: {project_root}")
+
+    cache_root = (
+        Path(args.cache_root) if args.cache_root else DEFAULT_CACHE_ROOT
+    )
+
+    if args.source:
+        source = Path(args.source)
+        if not (source / "skills").is_dir():
+            _fail(f"--source has no skills/ directory: {source}")
+    else:
+        source = discover_source(project_root, cache_root, args.verbose)
+
+    skills_dir = project_root / ".claude" / "skills"
+    deployed_version = read_module_version(
+        skills_dir / "bmad-pulse-setup" / "assets" / "module.yaml"
+    )
+
+    if source is None:
+        # Fresh install or cache unavailable — not an error. The BMAD
+        # installer deploys a clean tree on a first install; reconcile only
+        # matters when updating over a pre-existing install.
+        print(
+            json.dumps(
+                {
+                    "status": "success",
+                    "action": "skipped_no_source",
+                    "deployed_version": deployed_version,
+                    "notice": (
+                        "No PULSE source/cache located — nothing to "
+                        "reconcile (expected on a fresh install)."
+                    ),
+                },
+                indent=2,
+            )
+        )
+        return
+
+    source_skills_dir = source / "skills"
+    source_version = read_module_version(
+        source_skills_dir / "bmad-pulse-setup" / "assets" / "module.yaml"
+    )
+    source_skills = list_source_skills(source_skills_dir)
+    if not source_skills:
+        _fail(f"No skills found under {source_skills_dir}", code=2)
+
+    per_skill = {}
+    total_written = 0
+    total_deleted = 0
+    try:
+        for name in source_skills:
+            written, deleted = sync_skill(
+                source_skills_dir / name,
+                skills_dir / name,
+                args.dry_run,
+            )
+            if written or deleted:
+                per_skill[name] = {
+                    "written": written,
+                    "deleted": deleted,
+                }
+            total_written += len(written)
+            total_deleted += len(deleted)
+
+        legacy_removed = prune_legacy_folders(
+            skills_dir, source_skills, args.dry_run
+        )
+    except OSError as e:
+        _fail(f"Filesystem error during reconcile: {e}", code=2)
+
+    converged = bool(per_skill) or bool(legacy_removed)
+    result = {
+        "status": "success",
+        "action": "reconciled" if converged else "up_to_date",
+        "dry_run": args.dry_run,
+        "source": str(source.resolve()),
+        "from_version": deployed_version,
+        "to_version": source_version,
+        "skills_synced": sorted(per_skill.keys()),
+        "files_written": total_written,
+        "files_deleted": total_deleted,
+        "legacy_folders_removed": legacy_removed,
+        "details": per_skill,
+    }
+    if converged and deployed_version != source_version:
+        result["notice"] = (
+            f"PULSE reconciled {deployed_version} -> {source_version}. "
+            f"bmad-pulse-setup may have been updated in place; re-run "
+            f"/bmad-pulse-setup once more to execute the current version."
+        )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_reconcile_skills.py
+++ b/tests/unit/test_reconcile_skills.py
@@ -1,0 +1,208 @@
+"""Tests for reconcile-skills.py — idempotent self-heal of deployed skills.
+
+Covers the bug from issue #36: BMAD's additive deploy leaves pre-existing
+files stale and renamed folders orphaned when updating over an existing
+install. Reconcile must converge the deployed tree to the source version
+and be a no-op when already in sync.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parents[2]
+    / "skills/bmad-pulse-setup/scripts/reconcile-skills.py"
+)
+
+PULSE_SKILLS = [
+    "bmad-pulse-setup",
+    "bmad-agent-pulse",
+    "bmad-pulse-dashboard",
+    "bmad-pulse-track-start",
+    "bmad-pulse-track-done",
+]
+
+
+def run(project: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--project-root",
+            str(project),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def make_source(root: Path, version: str) -> Path:
+    """A fresh PULSE source tree at the given module_version."""
+    source = root / "source"
+    for skill in PULSE_SKILLS:
+        _write(source / "skills" / skill / "SKILL.md", f"---\nname: {skill}\n---\n")
+    _write(
+        source / "skills/bmad-pulse-setup/assets/module.yaml",
+        f"name: PULSE\ncode: pulse\nmodule_version: {version}\n",
+    )
+    return source
+
+
+def deploy_stale(project: Path, version: str) -> None:
+    """Simulate an additive BMAD deploy stuck at an older version:
+    pre-existing files frozen, plus an orphan renamed folder."""
+    skills = project / ".claude/skills"
+    for skill in PULSE_SKILLS:
+        _write(skills / skill / "SKILL.md", f"---\nname: {skill}\nSTALE\n---\n")
+    _write(
+        skills / "bmad-pulse-setup/assets/module.yaml",
+        f"name: PULSE\ncode: pulse\nmodule_version: {version}\n",
+    )
+    # Orphan folder from a pre-rename version (bmad-pulse-agent-levi ->
+    # bmad-agent-pulse in 0.4.5).
+    _write(skills / "bmad-pulse-agent-levi/SKILL.md", "---\nname: levi\n---\n")
+
+
+def test_reconciles_stale_install_to_source_version(tmp_path: Path):
+    source = make_source(tmp_path, "0.4.5")
+    project = tmp_path / "proj"
+    deploy_stale(project, "0.4.4")
+
+    result = run(project, "--source", str(source))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "reconciled"
+    assert payload["from_version"] == "0.4.4"
+    assert payload["to_version"] == "0.4.5"
+
+    deployed = (
+        project
+        / ".claude/skills/bmad-pulse-setup/assets/module.yaml"
+    ).read_text()
+    assert "module_version: 0.4.5" in deployed
+    assert "STALE" not in (
+        project / ".claude/skills/bmad-pulse-setup/SKILL.md"
+    ).read_text()
+
+
+def test_prunes_orphaned_renamed_folder(tmp_path: Path):
+    source = make_source(tmp_path, "0.4.5")
+    project = tmp_path / "proj"
+    deploy_stale(project, "0.4.4")
+
+    result = run(project, "--source", str(source))
+
+    payload = json.loads(result.stdout)
+    assert "bmad-pulse-agent-levi" in payload["legacy_folders_removed"]
+    assert not (project / ".claude/skills/bmad-pulse-agent-levi").exists()
+    assert (project / ".claude/skills/bmad-agent-pulse").is_dir()
+
+
+def test_idempotent_second_run_is_noop(tmp_path: Path):
+    source = make_source(tmp_path, "0.4.5")
+    project = tmp_path / "proj"
+    deploy_stale(project, "0.4.4")
+
+    first = run(project, "--source", str(source))
+    second = run(project, "--source", str(source))
+
+    assert json.loads(first.stdout)["action"] == "reconciled"
+    second_payload = json.loads(second.stdout)
+    assert second_payload["action"] == "up_to_date"
+    assert second_payload["files_written"] == 0
+    assert second_payload["files_deleted"] == 0
+    assert second_payload["legacy_folders_removed"] == []
+
+
+def test_dry_run_makes_no_writes(tmp_path: Path):
+    source = make_source(tmp_path, "0.4.5")
+    project = tmp_path / "proj"
+    deploy_stale(project, "0.4.4")
+
+    result = run(project, "--source", str(source), "--dry-run")
+
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    assert payload["action"] == "reconciled"
+    # Nothing actually changed on disk.
+    assert "STALE" in (
+        project / ".claude/skills/bmad-pulse-setup/SKILL.md"
+    ).read_text()
+    assert (project / ".claude/skills/bmad-pulse-agent-levi").exists()
+
+
+def test_skips_when_no_source_or_cache(tmp_path: Path):
+    """Fresh install path: no manifest, no cache — non-fatal skip so
+    bmad-pulse-setup can continue."""
+    project = tmp_path / "proj"
+    (project / ".claude/skills").mkdir(parents=True)
+
+    result = run(project, "--cache-root", str(tmp_path / "empty-cache"))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "skipped_no_source"
+
+
+def test_discovers_cache_from_manifest(tmp_path: Path):
+    project = tmp_path / "proj"
+    (project / ".claude/skills").mkdir(parents=True)
+    _write(
+        project / "_bmad/_config/manifest.yaml",
+        "modules:\n"
+        "  - name: core\n    version: 6.6.0\n"
+        "  - name: pulse\n"
+        "    version: main\n"
+        "    repoUrl: https://github.com/nidelson/bmad-module-pulse\n",
+    )
+    cache_root = tmp_path / "cache"
+    cache_dir = cache_root / "github.com/nidelson/bmad-module-pulse"
+    make_source(cache_dir.parent, "0.4.5")
+    # make_source writes to <parent>/source; relocate to the exact cache path
+    (cache_dir.parent / "source").rename(cache_dir)
+
+    result = run(project, "--cache-root", str(cache_root))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "reconciled"
+    assert payload["to_version"] == "0.4.5"
+
+
+def test_keeps_legacy_when_canonical_absent_from_source(tmp_path: Path):
+    """Safety: if the source set has no canonical replacement, the rename
+    did not happen in this version — do not prune the legacy folder."""
+    source = tmp_path / "source"
+    # Source WITHOUT bmad-agent-pulse.
+    _write(source / "skills/bmad-pulse-setup/SKILL.md", "---\nname: s\n---\n")
+    _write(
+        source / "skills/bmad-pulse-setup/assets/module.yaml",
+        "module_version: 0.4.5\n",
+    )
+    project = tmp_path / "proj"
+    _write(
+        project / ".claude/skills/bmad-pulse-agent-levi/SKILL.md",
+        "---\nname: levi\n---\n",
+    )
+
+    result = run(project, "--source", str(source))
+
+    payload = json.loads(result.stdout)
+    assert payload["legacy_folders_removed"] == []
+    assert (project / ".claude/skills/bmad-pulse-agent-levi").exists()
+
+
+def test_errors_on_missing_project_root(tmp_path: Path):
+    result = run(tmp_path / "does-not-exist", "--source", str(tmp_path))
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["status"] == "error"


### PR DESCRIPTION
Closes #36

## Problem

The upstream BMAD installer performs an **additive deploy** when PULSE is already installed: new files are copied, but pre-existing files (`module.yaml`, `SKILL.md`, …) are never overwritten and renamed/removed skills are never pruned. Re-running install over an existing project leaves a mixed state frozen at the old version (real case: a downstream project stuck at PULSE 0.4.4 after 0.4.5 release, with an orphaned `bmad-pulse-agent-levi/`).

## Fix

- **`scripts/reconcile-skills.py`** — discovers the BMAD custom-module cache from `_bmad/_config/manifest.yaml` (or explicit `--source`), force-syncs every PULSE skill dir via sha256 content compare, prunes known renamed legacy folders (`bmad-pulse-agent-levi` → `bmad-agent-pulse`). Idempotent (`up_to_date` no-op), non-fatal on fresh installs (`skipped_no_source`), `--dry-run` supported. No new deps (`dependencies = []`).
- **`SKILL.md`** — runs reconcile as the first setup step so any client with a pre-existing install self-heals on the next `/bmad-pulse-setup`.
- **`MIGRATION.md`** — documents the additive-installer behavior + automatic self-heal (general, all versions).

## Tests

`tests/unit/test_reconcile_skills.py` — 8 cases: stale→reconcile convergence, orphan prune, idempotent second run, dry-run, fresh-install skip, cache discovery from manifest, legacy-kept-when-no-canonical safety, bad project root. Full suite: **86 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)