### PR TITLE
feat: add pulse_estimation_method=bcp for Business Complexity Points integration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,12 @@ Composite score based on:
 - HALT count
 - Available skills that were not used
 
+## Integrations
+
+- [BCP — Business Complexity Points](integration/bcp.md) — opt-in
+  `pulse_estimation_method=bcp` for teams estimating in BCP via the companion
+  [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp) module.
+
 ## Advanced Configuration
 
 See [module.yaml](../module.yaml) for the full list of configurable variables. The file at the repository root is a symlink to the canonical manifest shipped inside the setup skill (`skills/bmad-pulse-setup/assets/module.yaml`), so the BMAD installer can copy it to the consumer project at install time while keeping the file discoverable from the repo root.

--- a/docs/integration/bcp.md
+++ b/docs/integration/bcp.md
@@ -1,0 +1,130 @@
+# PULSE ↔ BCP Integration
+
+`pulse_estimation_method=bcp` lets PULSE report productivity for teams that
+estimate in **Business Complexity Points** (BCP, a CI&T-shaped methodology —
+<https://ciandt.com/us/en-us/complexitypoints>) instead of raw hours.
+
+PULSE stays **passive and zero-coupled**: it never computes hours from BCP,
+never owns the BCP baseline, and never writes to story frontmatter. The scoring
+side — the Bruno agent, scoring rules, baseline calibration, and the
+`estimated_hours` derivation — lives entirely in the companion module
+[`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp).
+
+## Ownership Boundary
+
+PULSE → BCP coupling: **zero**. PULSE does not know how BCP scores anything.
+BCP → PULSE coupling: **zero**. BCP optionally reads `pulse_metrics` in its own
+`recalibrate` skill, by file convention only.
+
+| Field                       | Owner                                                        |
+| --------------------------- | ------------------------------------------------------------ |
+| `estimated_hours` (story)   | BMAD/Amelia originally; BCP overwrites if installed (install = consent) |
+| `estimated_hours_pre_bcp`   | BCP (audit — PULSE ignores)                                   |
+| `estimated_hours_basis`     | BCP (audit — PULSE ignores)                                   |
+| `bcp.*` (story frontmatter) | BCP exclusively — PULSE reads, never writes                   |
+| `bcp-baseline.yaml`         | BCP exclusively — PULSE never reads or writes                 |
+| `pulse_metrics.*`           | PULSE exclusively                                             |
+| `actual_hours`              | PULSE                                                         |
+
+PULSE's only behavioral change is **semantic**: `bcp` tells PULSE the upstream
+`estimated_hours` was BCP-derived, so the dashboard surfaces a BCP section. It
+does *not* mean PULSE converts BCP points to hours.
+
+## Frontmatter PULSE Reads (story file, read-only)
+
+```yaml
+---
+story_id: "5.7"
+estimated_hours: 86.7              # PULSE reads this — writer-agnostic
+estimated_hours_pre_bcp: 80        # BCP audit — PULSE ignores
+estimated_hours_basis: bcp         # BCP audit — PULSE ignores
+category: backend
+
+bcp:                               # written by BCP — PULSE surfaces it
+  schema_version: "1.0"
+  rule_version: "1.0"
+  total: 21
+  scored_at: "<iso8601>"
+  scored_by: bruno
+  breakdown: { ... }               # PULSE does NOT interpret this
+  history: []                      # PULSE does NOT interpret this
+---
+```
+
+## Behavior Rules
+
+| Condition                                              | PULSE behavior                                                                                          |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `bcp` block absent                                     | Behave as today (no change).                                                                            |
+| `bcp` present, `pulse_estimation_method=bcp`           | Use `estimated_hours` as-is (already overwritten by BCP). Snapshot `bcp_at_start`. Surface BCP section.  |
+| `bcp` present, `pulse_estimation_method≠bcp`           | Use `estimated_hours` as today. Still record `bcp_at_start` as opt-in telemetry.                          |
+| `bcp.schema_version` unknown (≠ `"1.0"`)               | Emit a one-line warning, ignore `bcp.*` for that story.                                                  |
+
+## Configuration
+
+```yaml
+# _bmad/config.yaml — pulse section
+pulse_estimation_method: bcp        # 4th value, alongside hours / story_points / tshirt
+```
+
+No baseline-related keys live in PULSE. With `bcp`, `pulse_story_point_hours_factor`
+is **not** required — there is no conversion factor; hours are derived upstream.
+
+## Track-Start Extension
+
+When a valid `bcp:` block is present, `bmad-pulse-track-start` snapshots it:
+
+```yaml
+pulse_metrics:
+  "5.7":
+    start_ts: "..."
+    estimated_hours: 86.7
+    estimation_basis: bcp
+    bcp_at_start:
+      total: 21
+      rule_version: "1.0"
+      scored_by: bruno
+```
+
+## Track-Done Extension
+
+When a BCP total is available (`bcp_at_start.total`, or story `bcp.total` as
+fallback), `bmad-pulse-track-done` records:
+
+```yaml
+pulse_metrics:
+  "5.7":
+    # ... existing fields ...
+    bcp_recorded:
+      total: 21
+      h_per_bcp_actual: 4.13        # actual_hours / bcp.total
+      h_per_bcp_estimated: 4.13     # estimated_hours / bcp.total
+      drift_pct: 0.0
+```
+
+PULSE does **not** update any baseline. Baseline maturation is the BCP module's
+responsibility (via `/bmad-bcp-recalibrate`).
+
+## Dashboard Extension
+
+A conditional **📊 BCP Productivity** section appears only when ≥1 story has a
+`bcp_recorded` block. It renders BCP throughput per epic, actual vs estimated
+h/BCP per category, a drift trend, and top stories by BCP total.
+
+> **Design note — "top elements driving BCP":** the original feature request
+> mentioned per-element ranking. PULSE intentionally ranks by *story-level* BCP
+> total instead, because `bcp.breakdown` (the per-element data) is owned by
+> `bmad-module-bcp`. Reading it here would break zero coupling. Per-element
+> analytics belong in the BCP module's own reporting.
+
+## Backwards Compatibility
+
+Stories without a `bcp` block behave exactly as before. The BCP section is
+absent unless BCP data exists. All four `pulse_estimation_method` values
+(`hours`, `story_points`, `tshirt`, `bcp`) are supported.
+
+## Related
+
+- Companion module (scoring side): <https://github.com/nidelson/bmad-module-bcp>
+- Companion issue: <https://github.com/nidelson/bmad-module-bcp/issues/1>
+- BCP framework reference: <https://ciandt.com/us/en-us/complexitypoints>

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -93,6 +93,14 @@ Load the `pulse` section from `{main_config}` and resolve all module variables:
        - `total_pre_approved_batch_count` — count of `approval_wait` entries with `pre_approved_batch: true` (Shape B only)
        - `legacy_halt_string_count` — count of Shape C entries encountered (used to surface migration hint in insights)
        - `stories_with_approval_wait` — list of `(story_id, total_minutes)` pairs for the breakdown table (entries with unknown minutes show as `?min`)
+   - **BCP aggregations** (read `bcp_recorded` and `bcp_at_start` / `estimation_basis` from each story; all optional — a story without them is normal and contributes nothing):
+     - `bcp_stories` — list of stories that have a `bcp_recorded` block
+     - `total_bcp` — sum of `bcp_recorded.total` across `bcp_stories`
+     - `bcp_throughput` — `total_bcp` grouped by epic (proxy for BCP/sprint when sprint segmentation is unavailable)
+     - `h_per_bcp_by_category` — for each category in `{pulse_dev_categories}`, the mean of `bcp_recorded.h_per_bcp_actual` over its `bcp_stories`
+     - `h_per_bcp_estimated_by_category` — same, over `bcp_recorded.h_per_bcp_estimated` (for the drift comparison)
+     - `drift_trend` — ordered list of `(story_id, bcp_recorded.drift_pct)` for `bcp_stories` (story-order = chronological proxy)
+     - `top_bcp_stories` — `bcp_stories` sorted by `bcp_recorded.total` desc, top 5 (proxy for "elements driving BCP" — PULSE does not read `bcp.breakdown`, so it ranks by total points per story)
 
 ### Step 2: Generate Dashboard
 
@@ -175,6 +183,51 @@ Based on avg leverage of {avg}x:
 {end}
 <!-- END CONDITIONAL approval_wait -->
 
+<!-- CONDITIONAL: include only if bcp_stories is non-empty (≥1 story has a bcp_recorded block) -->
+## 📊 BCP Productivity
+
+> Business Complexity Points telemetry. Hours were derived upstream by
+> [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp); PULSE only
+> reports observed productivity and never owns the BCP baseline.
+
+| Metric                | Value          |
+| --------------------- | -------------- |
+| Stories with BCP      | {len(bcp_stories)} |
+| Total BCP scored      | {total_bcp}    |
+
+**Throughput (BCP per epic):**
+
+{for each epic in bcp_throughput}
+Epic {N}: {bcp} BCP ({count} stories)
+{end}
+
+**Actual h/BCP by category:**
+
+| Category | Actual h/BCP | Est. h/BCP | Drift |
+| -------- | ------------ | ---------- | ----- |
+{for each category with bcp_stories}
+| {category} | {h_per_bcp_by_category}h | {h_per_bcp_estimated_by_category}h | {drift:+}% |
+{end}
+
+**Drift trend (estimated vs actual h/BCP):**
+
+{for each (story_id, drift_pct) in drift_trend}
+{story_id}: {drift_pct:+}%
+{end}
+
+**Top stories by BCP:**
+
+| Story | BCP | Actual h/BCP |
+| ----- | --- | ------------ |
+{for each story in top_bcp_stories}
+| {story_id} | {bcp_recorded.total} | {bcp_recorded.h_per_bcp_actual}h |
+{end}
+
+> Note: PULSE ranks by story-level BCP total. Per-element breakdown
+> (`bcp.breakdown`) is owned by `bmad-module-bcp` and is intentionally not
+> read here — this preserves zero coupling.
+<!-- END CONDITIONAL bcp -->
+
 ## 💡 Process Insights
 
 {insights generated based on the data}
@@ -223,6 +276,8 @@ The detail level of the summary must respect `pulse_levi_verbosity`.
 - The capacity forecast section must only be included if `pulse_include_capacity_forecast == yes`
 - The categories table must use the categories defined in `pulse_dev_categories` (not hardcoded categories)
 - The Approval-Wait Halts section must only be rendered when `total_approval_wait_count + total_pre_approved_batch_count > 0`
+- The BCP Productivity section must only be rendered when at least one story has a `bcp_recorded` block; stories without BCP data render unchanged in all other sections
+- Never read or write the BCP baseline file — BCP productivity is computed purely from `pulse_metrics` fields PULSE itself recorded
 - When reading `process_health.halts`, accept both shapes (integer count and structured list) and degrade gracefully — never crash on legacy data
 
 ---

--- a/skills/bmad-pulse-setup/SKILL.md
+++ b/skills/bmad-pulse-setup/SKILL.md
@@ -72,6 +72,7 @@ Ask the user for values. Show defaults in brackets. Present all values together 
 
 **Validation rules:**
 - If `pulse_estimation_method` = `story_points` and `pulse_story_point_hours_factor` has not been set, warn before continuing
+- If `pulse_estimation_method` = `bcp`: do **not** require `pulse_story_point_hours_factor` (no factor applies — `estimated_hours` is derived upstream by [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp), not converted by PULSE). The value is semantic-only: it tells PULSE the upstream hours came from BCP so the dashboard surfaces the BCP Productivity section. Inform the user that the companion `bmad-module-bcp` module must be installed for `estimated_hours` to be BCP-derived; PULSE itself stays passive if it is not.
 - If `pulse_dev_categories` = `custom`, request a comma-separated list
 
 ## Write Files

--- a/skills/bmad-pulse-setup/assets/module.yaml
+++ b/skills/bmad-pulse-setup/assets/module.yaml
@@ -28,6 +28,10 @@ pulse_estimation_method:
       label: Story Points (requires calibration factor)
     - value: tshirt
       label: T-Shirt Sizes (S/M/L/XL — normalized automatically)
+    - value: bcp
+      label: >-
+        Business Complexity Points (estimated_hours derived upstream by
+        bmad-module-bcp — PULSE stays passive)
 pulse_story_point_hours_factor:
   prompt: How many hours on average equal 1 story point in your team?
   default: '4.0'

--- a/skills/bmad-pulse-track-done/workflow.md
+++ b/skills/bmad-pulse-track-done/workflow.md
@@ -58,7 +58,7 @@ Load the config from the `pulse` section of `{main_config}` and resolve all modu
 - `output_folder`, `user_name`, `communication_language`
 - `pulse_data_folder`, `pulse_dashboard_folder`
 - `pulse_sprint_status_filename`
-- `pulse_estimation_method` (story_points / hours / t-shirt)
+- `pulse_estimation_method` (story_points / hours / t-shirt / bcp)
 - `pulse_story_point_hours_factor` (story points → hours conversion factor)
 - `pulse_leverage_threshold_exceptional` (e.g. 4)
 - `pulse_leverage_threshold_solid` (e.g. 2)
@@ -139,6 +139,15 @@ If `pulse_estimation_method` is `hours`:
 estimated_hours = value recorded directly in hours
 ```
 
+If `pulse_estimation_method` is `bcp`:
+
+```text
+estimated_hours = value recorded directly in hours
+                  (already derived upstream by bmad-module-bcp — PULSE does NOT
+                   compute hours from BCP points; it consumes the field as-is,
+                   identical to the `hours` branch)
+```
+
 **Leverage calculation:**
 
 ```text
@@ -174,6 +183,38 @@ first_pass = review_cycles == 1
 3. Add the `leverage_ratio` field with the calculated value (1 decimal)
 4. Add the `first_pass` field as a boolean
 
+**BCP productivity (only when a BCP total is available for this story):**
+
+Resolve `bcp_total` as `pulse_metrics[story].bcp_at_start.total` (snapshotted by
+track-start). If that snapshot is absent, re-read the story frontmatter `bcp.total`
+(read-only) as a fallback. If neither yields a number, skip this block entirely —
+behave exactly as today.
+
+When `bcp_total` is a positive number, add a `bcp_recorded` field to the story
+entry in `pulse_metrics`:
+
+```text
+h_per_bcp_actual    = round(actual_hours    / bcp_total, 2)
+h_per_bcp_estimated = round(estimated_hours / bcp_total, 2)
+drift_pct           = round((h_per_bcp_actual - h_per_bcp_estimated)
+                            / h_per_bcp_estimated * 100, 1)   # 0.0 if estimated == 0
+```
+
+```yaml
+pulse_metrics:
+  "5.7":
+    # ... existing fields ...
+    bcp_recorded:
+      total: 21
+      h_per_bcp_actual: 4.13
+      h_per_bcp_estimated: 4.13
+      drift_pct: 0.0
+```
+
+PULSE does **not** update any BCP baseline. Baseline maturation is the
+`bmad-module-bcp` module's responsibility (via `/bmad-bcp-recalibrate`). This step
+only records read-derived telemetry inside the `pulse_metrics:` section.
+
 ### Step 4: Generate Efficiency Pulse + Process Health
 
 Display in the terminal:
@@ -185,6 +226,7 @@ Display in the terminal:
    Human estimate: {estimated_hours}h ({dev_count} devs)
    Actual AI time: {actual_hours}h ({elapsed_minutes}min wall-clock)
    AI Leverage: {leverage_ratio}x
+   {if bcp_recorded}BCP: {bcp_recorded.total} pts | {bcp_recorded.h_per_bcp_actual}h/BCP actual vs {bcp_recorded.h_per_bcp_estimated}h/BCP est ({bcp_recorded.drift_pct:+}% drift){end}
    Quality: {first_pass ? "✅ first-pass" : "🔄 " + review_cycles + " cycles"}
    Tasks: {task_count}
    Category: {category}
@@ -318,6 +360,7 @@ Display as an additional section in the card (respecting `pulse_levi_verbosity`)
 ## BEHAVIOR RESTRICTIONS
 
 - DO NOT modify anything outside the `pulse_metrics:` section of file `{sprint_status_file}`
+- DO NOT write to the story frontmatter or to any BCP baseline file (`bcp-baseline.yaml`) — `bcp.*` is read-only input owned by `bmad-module-bcp`; baseline recalibration lives in that module
 - Data is isolated in the `pulse_metrics:` section — zero risk of conflict
 - Communicate in the language configured in `communication_language`
 - Respect `pulse_levi_verbosity` for level of detail (concise / standard / verbose)

--- a/skills/bmad-pulse-track-start/workflow.md
+++ b/skills/bmad-pulse-track-start/workflow.md
@@ -56,6 +56,7 @@ Load the PULSE configuration as described in INITIALIZATION below, then execute 
 Load the `pulse` section from `{main_config}` and resolve module variables:
 
 - `output_folder`, `user_name`, `communication_language`
+- `pulse_estimation_method` — `hours` / `story_points` / `tshirt` / `bcp`
 - `pulse_field_estimated_hours` — name of the hours/points estimate field in the story file
 - `pulse_field_dev_count` — name of the estimated developer count field in the story file
 - `pulse_field_category` — name of the category field in the story file
@@ -66,6 +67,13 @@ Load the `pulse` section from `{main_config}` and resolve module variables:
 > **Note on `pulse_estimation_method`:** If the value is `story_points`, the field pointed to by
 > `pulse_field_estimated_hours` contains story points, not hours. The record should reflect this
 > (e.g. display as "estimated points" instead of "estimated hours").
+>
+> **Note on `bcp` (Business Complexity Points):** PULSE stays **passive and zero-coupled** —
+> it does NOT compute hours from BCP. The `bcp` value only signals that the upstream
+> `estimated_hours` was already derived by the [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp)
+> module (install = consent to overwrite). PULSE reads `estimated_hours` exactly as for
+> `hours`, and additionally snapshots the `bcp.*` block for audit (see Step 2/3). PULSE
+> never writes to the story frontmatter and never touches the BCP baseline file.
 
 ### Paths
 
@@ -91,6 +99,10 @@ Load the `pulse` section from `{main_config}` and resolve module variables:
    - The field configured in `pulse_field_dev_count` (estimated number of developers)
    - `task_count` (number of tasks/subtasks — internal PULSE field, always present)
    - The field configured in `pulse_field_category` (story category — infer from name; if ambiguous, ask the user using the valid categories defined in `pulse_dev_categories`)
+   - The `bcp:` frontmatter block, **only if present** (written exclusively by `bmad-module-bcp`):
+     - Read `bcp.schema_version`. If it is a value this skill does not recognize (anything other than `"1.0"`), emit a one-line warning (`⚠ Unknown bcp.schema_version <v> — ignoring bcp.* for this story`) and treat the block as absent for the rest of the workflow.
+     - Otherwise capture `bcp.total`, `bcp.rule_version`, and `bcp.scored_by` for the snapshot in Step 3. PULSE does not interpret `bcp.breakdown` or `bcp.history`.
+     - This extraction is **read-only** — PULSE never writes back to the story frontmatter.
 
 ### Step 3: Record in the file configured in `pulse_sprint_status_filename`
 
@@ -101,6 +113,26 @@ Load the `pulse` section from `{main_config}` and resolve module variables:
    - `dev_count`: value extracted from the `pulse_field_dev_count` field
    - `task_count`: extracted value
    - `category`: value inferred or confirmed by the user (from the categories in `pulse_dev_categories`)
+3. **BCP snapshot (only when a valid `bcp:` block was captured in Step 2):** add to the same story entry:
+   - `estimation_basis: bcp`
+   - `bcp_at_start:` with `total`, `rule_version`, `scored_by` taken from the `bcp.*` block
+
+   ```yaml
+   pulse_metrics:
+     "5.7":
+       start_ts: "..."
+       estimated_hours: 86.7
+       estimation_basis: bcp
+       bcp_at_start:
+         total: 21
+         rule_version: "1.0"
+         scored_by: bruno
+   ```
+
+   When `pulse_estimation_method` is not `bcp` but a valid `bcp:` block is present, the
+   snapshot is still recorded as opt-in telemetry (`estimation_basis` reflects the
+   configured method, `bcp_at_start` is added alongside). When no valid `bcp:` block is
+   present, omit both fields entirely — behave exactly as today.
 
 ### Step 4: Confirm
 
@@ -111,6 +143,7 @@ Display:
    Story: {story_id}
    Timestamp: {start_ts}
    Human estimate: {estimated_hours}h ({dev_count} devs)
+   {if bcp_at_start}BCP: {bcp_at_start.total} pts (rule {bcp_at_start.rule_version}, scored by {bcp_at_start.scored_by}){end}
    Tasks: {task_count}
    Category: {category}
    ⏱️ The clock is running...
@@ -121,6 +154,7 @@ Display:
 ## BEHAVIOR RESTRICTIONS
 
 - DO NOT modify anything outside the `pulse_metrics:` section of the sprint-status file
+- DO NOT write to the story file frontmatter or to any BCP baseline file — `bcp.*` is read-only input owned by `bmad-module-bcp`
 - If an entry already exists for this story ID in `pulse_metrics:`, ask whether to overwrite
 - Create the `pulse_metrics:` section if it does not exist
 - Communicate in the language configured in `communication_language`

--- a/tests/test_bcp_integration.py
+++ b/tests/test_bcp_integration.py
@@ -1,0 +1,117 @@
+"""Invariant tests for the BCP (Business Complexity Points) integration.
+
+Issue #30: PULSE accepts `pulse_estimation_method=bcp` and surfaces BCP
+telemetry while staying passive and zero-coupled to `bmad-module-bcp`.
+
+These are meta/invariant tests in the same spirit as
+``test_cross_file_invariants.py`` — they pin the loose-coupling contract in
+the workflow markdown so a future edit cannot silently make PULSE compute
+hours from BCP or write the BCP baseline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parents[1]
+MODULE_YAML = REPO_ROOT / "skills/bmad-pulse-setup/assets/module.yaml"
+TRACK_START = REPO_ROOT / "skills/bmad-pulse-track-start/workflow.md"
+TRACK_DONE = REPO_ROOT / "skills/bmad-pulse-track-done/workflow.md"
+DASHBOARD = REPO_ROOT / "skills/bmad-pulse-dashboard/workflow.md"
+SETUP_SKILL = REPO_ROOT / "skills/bmad-pulse-setup/SKILL.md"
+BCP_DOC = REPO_ROOT / "docs/integration/bcp.md"
+
+EXPECTED_METHODS = {"hours", "story_points", "tshirt", "bcp"}
+
+
+def test_module_yaml_offers_exactly_four_estimation_methods():
+    """module.yaml pins the supported estimation methods. `bcp` is the 4th;
+    the set must stay exactly these four so docs/tests/workflows agree."""
+    data = yaml.safe_load(MODULE_YAML.read_text())
+    entry = data["pulse_estimation_method"]
+    values = {opt["value"] for opt in entry["single-select"]}
+    assert values == EXPECTED_METHODS, (
+        f"pulse_estimation_method values {sorted(values)} != "
+        f"expected {sorted(EXPECTED_METHODS)}"
+    )
+    assert entry["default"] == "hours", "bcp must be opt-in, not the default"
+
+
+def test_bcp_label_attributes_hours_to_upstream_module():
+    """The bcp option label must make clear PULSE does not compute the hours
+    (estimated_hours is derived upstream by bmad-module-bcp)."""
+    data = yaml.safe_load(MODULE_YAML.read_text())
+    label = next(
+        opt["label"]
+        for opt in data["pulse_estimation_method"]["single-select"]
+        if opt["value"] == "bcp"
+    )
+    assert "bmad-module-bcp" in label
+    assert "estimated_hours" in label
+
+
+def test_track_done_config_doc_lists_bcp():
+    """The track-done config-loading line enumerates the methods; bcp must be
+    listed so the workflow's own documentation matches module.yaml."""
+    text = TRACK_DONE.read_text()
+    assert "story_points / hours / t-shirt / bcp" in text, (
+        "track-done config line must enumerate bcp alongside the other methods"
+    )
+
+
+def test_track_done_consumes_estimated_hours_as_is_for_bcp():
+    """PULSE must NOT convert BCP points to hours — the bcp branch reads
+    estimated_hours directly, identical to the hours branch."""
+    text = TRACK_DONE.read_text()
+    assert "If `pulse_estimation_method` is `bcp`:" in text
+    # The bcp branch must explicitly disclaim hour computation.
+    assert "does NOT" in text and "compute hours from BCP" in text
+
+
+def test_track_start_snapshots_bcp_at_start():
+    text = TRACK_START.read_text()
+    assert "bcp_at_start" in text
+    assert "estimation_basis: bcp" in text
+    # Unknown schema_version must be tolerated, not crash.
+    assert "schema_version" in text
+
+
+def test_track_done_records_bcp_recorded():
+    text = TRACK_DONE.read_text()
+    assert "bcp_recorded" in text
+    for field in ("h_per_bcp_actual", "h_per_bcp_estimated", "drift_pct"):
+        assert field in text, f"track-done must record {field}"
+
+
+def test_dashboard_bcp_section_is_conditional():
+    """The BCP Productivity section must be gated on bcp_recorded existing —
+    stories without BCP must not trigger it."""
+    text = DASHBOARD.read_text()
+    assert "📊 BCP Productivity" in text
+    assert "CONDITIONAL" in text and "bcp_recorded" in text
+
+
+def test_pulse_never_writes_story_frontmatter_or_baseline():
+    """Loose-coupling contract: every workflow that touches bcp.* must state
+    it is read-only and never writes the BCP baseline."""
+    for wf in (TRACK_START, TRACK_DONE):
+        text = wf.read_text()
+        assert "baseline" in text.lower(), f"{wf.name} must mention baseline boundary"
+        assert "read-only" in text.lower() or "DO NOT write" in text, (
+            f"{wf.name} must assert read-only handling of bcp.*"
+        )
+
+
+def test_setup_skill_waives_factor_for_bcp():
+    """bcp must not require pulse_story_point_hours_factor."""
+    text = SETUP_SKILL.read_text()
+    assert "pulse_estimation_method` = `bcp`" in text
+    assert "not** require `pulse_story_point_hours_factor`" in text
+
+
+def test_bcp_integration_doc_exists_and_states_zero_coupling():
+    assert BCP_DOC.exists(), "docs/integration/bcp.md must exist"
+    text = BCP_DOC.read_text()
+    assert "zero-coupled" in text or "zero coupling" in text
+    assert "bmad-module-bcp" in text


### PR DESCRIPTION
Closes #30. Target release: v0.5.0 (minor — additive, no breaking changes).

## Summary

Adds `bcp` as a fourth `pulse_estimation_method` value alongside `hours` / `story_points` / `tshirt`. PULSE remains **passive and zero-coupled** to [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp): it consumes `estimated_hours` as-is (derived upstream by BCP, never computed from BCP points) and surfaces a conditional BCP-aware dashboard section when `bcp` data is present.

## Changes

| File | What |
|---|---|
| `module.yaml` | `bcp` = 4th option, opt-in (`hours` stays default) |
| `track-start/workflow.md` | snapshot `bcp_at_start` + `estimation_basis`; warn+ignore unknown `bcp.schema_version`; read-only on story frontmatter |
| `track-done/workflow.md` | `bcp` branch consumes `estimated_hours` unchanged; records `bcp_recorded` {h_per_bcp_actual, h_per_bcp_estimated, drift_pct}; never writes BCP baseline |
| `dashboard/workflow.md` | conditional "📊 BCP Productivity" section gated on `bcp_recorded`; existing panels unchanged |
| `setup/SKILL.md` | `bcp` waives `pulse_story_point_hours_factor` |
| `docs/integration/bcp.md` + `index.md` | ownership boundary, behavior rules, integration guide |
| `tests/test_bcp_integration.py` | 10 invariants |

## Acceptance Criteria

- [x] `pulse_estimation_method` accepts `bcp`
- [x] track-start snapshots `bcp_at_start` when `bcp` block present
- [x] track-done records `bcp_recorded` when BCP total present
- [x] Dashboard renders BCP Productivity section conditionally
- [x] Backwards compatible (stories without `bcp` unchanged)
- [x] Schema validation warns on unknown `bcp.schema_version`
- [x] Documentation: `docs/integration/bcp.md` + index link
- [x] Tests cover all four `pulse_estimation_method` values
- [x] PULSE never writes story frontmatter or BCP baseline

## Design note

"Top elements driving BCP" is ranked by story-level BCP total, not `bcp.breakdown`. PULSE does not read `bcp.breakdown` (owned by `bmad-module-bcp`) — preserves zero coupling. Per-element analytics belong to the BCP module. Documented in `docs/integration/bcp.md`.

## Test

`96 passed` (86 baseline + 10 new BCP invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)