### PR TITLE
feat: bmad-pulse-track-backfill — retroactive HI/HF recording for unmeasured stories

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,7 @@
         "./skills/bmad-agent-pulse",
         "./skills/bmad-pulse-track-start",
         "./skills/bmad-pulse-track-done",
+        "./skills/bmad-pulse-track-backfill",
         "./skills/bmad-pulse-dashboard"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Then in your BMAD project:
 /bmad-pulse-setup            # Configure once
 /bmad-pulse-track-start      # When you start a story
 /bmad-pulse-track-done       # When you finish — leverage is computed
+/bmad-pulse-track-backfill   # Forgot to track? Recover HI/HF after the fact
 /bmad-pulse-dashboard        # See the cumulative trend
 ```
 
@@ -136,6 +137,7 @@ PULSE attaches to your existing BMAD story files — no schema migrations, no se
 | `bmad-pulse-setup` | `/bmad-pulse-setup` | Configure the module in your project |
 | `bmad-pulse-track-start` | `/bmad-pulse-track-start [story_id]` | Register story start |
 | `bmad-pulse-track-done` | `/bmad-pulse-track-done [story_id]` | Register completion + calculate metrics |
+| `bmad-pulse-track-backfill` | `/bmad-pulse-track-backfill [story_id] --hi <ts> --hf <ts>` | Retroactively record HI/HF + metrics for a story tracked too late |
 | `bmad-pulse-dashboard` | `/bmad-pulse-dashboard` | Generate cumulative dashboard |
 
 ---

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -104,6 +104,7 @@ Depois, no seu projeto BMAD:
 /bmad-pulse-setup            # Configure uma vez
 /bmad-pulse-track-start      # Quando começar uma story
 /bmad-pulse-track-done       # Quando terminar — alavancagem é calculada
+/bmad-pulse-track-backfill   # Esqueceu de medir? Recupere HI/HF depois do fato
 /bmad-pulse-dashboard        # Veja a tendência cumulativa
 ```
 
@@ -120,6 +121,7 @@ PULSE se conecta aos seus arquivos de story BMAD existentes — sem migrations, 
 | `bmad-pulse-setup` | `/bmad-pulse-setup` | Configura o módulo no seu projeto |
 | `bmad-pulse-track-start` | `/bmad-pulse-track-start [story_id]` | Registra início da story |
 | `bmad-pulse-track-done` | `/bmad-pulse-track-done [story_id]` | Registra conclusão + calcula métricas |
+| `bmad-pulse-track-backfill` | `/bmad-pulse-track-backfill [story_id] --hi <ts> --hf <ts>` | Registra HI/HF + métricas retroativamente para story medida tarde demais |
 | `bmad-pulse-dashboard` | `/bmad-pulse-dashboard` | Gera dashboard cumulativo |
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,14 @@
 4. When completing: `/bmad-pulse-track-done`
 5. To view the dashboard: `/bmad-pulse-dashboard`
 
+> **Missed tracking a story?** Early-adoption stories or workflow
+> interruptions sometimes skip track-start/track-done. Recover the lost
+> measurement after the fact:
+> `/bmad-pulse-track-backfill 1.2 --hi "2026-05-18 14:00" --hf "2026-05-18 15:00"`.
+> Backfilled entries are flagged `retroactive: true` for traceability and
+> deliberately omit `process_health` — halts and BMAD flow cannot be
+> reconstructed honestly after the fact.
+
 ## Metrics Reference
 
 ### AI Leverage Ratio

--- a/skills/bmad-agent-pulse/SKILL.md
+++ b/skills/bmad-agent-pulse/SKILL.md
@@ -77,11 +77,12 @@ From here, Levi stays active — persona, persistent facts, `{agent.icon}` prefi
 
 ## Capabilities (default menu, before customization)
 
-The customize.toml `[[agent.menu]]` defaults expose three capabilities. Team or
+The customize.toml `[[agent.menu]]` defaults expose four capabilities. Team or
 user overrides may merge by `code` to replace entries or append new ones.
 
 | Code | Description                                                            | Skill                  |
 | ---- | ---------------------------------------------------------------------- | ---------------------- |
 | TS   | Track Start: register the start of story implementation                | bmad-pulse-track-start |
 | TD   | Track Done: register completion, calculate metrics, show the Pulse     | bmad-pulse-track-done  |
+| BF   | Track Backfill: retroactively record HI/HF + metrics for an unmeasured story | bmad-pulse-track-backfill |
 | DB   | Dashboard: generate the cumulative efficiency dashboard                | bmad-pulse-dashboard   |

--- a/skills/bmad-agent-pulse/customize.toml
+++ b/skills/bmad-agent-pulse/customize.toml
@@ -75,6 +75,11 @@ description = "Track Done — register completion, calculate metrics, show the E
 skill = "bmad-pulse-track-done"
 
 [[agent.menu]]
+code = "BF"
+description = "Track Backfill — retroactively record HI/HF and metrics for an unmeasured story"
+skill = "bmad-pulse-track-backfill"
+
+[[agent.menu]]
 code = "DB"
 description = "Dashboard — generate the cumulative efficiency dashboard"
 skill = "bmad-pulse-dashboard"

--- a/skills/bmad-pulse-setup/assets/module-help.csv
+++ b/skills/bmad-pulse-setup/assets/module-help.csv
@@ -1,4 +1,5 @@
 module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
 PULSE,bmad-pulse-track-start,Track Start,TS,"Record start of story implementation",track-start,"[story_id]",anytime,,,false,pulse_data_folder,"pulse_metrics entry"
 PULSE,bmad-pulse-track-done,Track Done,TD,"Record completion and calculate metrics",track-done,"[story_id]",anytime,bmad-pulse-track-start:track-start,,false,pulse_data_folder,"leverage_ratio first_pass process_health"
+PULSE,bmad-pulse-track-backfill,Track Backfill,TB,"Retroactively record HI/HF and metrics for an unmeasured story",track-backfill,"[story_id] --hi <ts> --hf <ts>",anytime,,,false,pulse_data_folder,"retroactive pulse_metrics entry"
 PULSE,bmad-pulse-dashboard,Dashboard,PD,"Generate cumulative efficiency dashboard",dashboard,"",anytime,bmad-pulse-track-done:track-done,,false,pulse_dashboard_folder,"dashboard markdown"

--- a/skills/bmad-pulse-track-backfill/SKILL.md
+++ b/skills/bmad-pulse-track-backfill/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: bmad-pulse-track-backfill
+description: 'Retroactively record HI/HF (start/end) and PULSE metrics for a story whose track-start/track-done were never run. Use when adopting PULSE mid-project or after a workflow interruption left a story unmeasured.'
+standalone: true
+main_config: '{project-root}/_bmad/config.yaml'
+config_section: 'pulse'
+---
+
+Follow the instructions in [workflow.md](workflow.md).

--- a/skills/bmad-pulse-track-backfill/customize.toml
+++ b/skills/bmad-pulse-track-backfill/customize.toml
@@ -1,0 +1,41 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for bmad-pulse-track-backfill. Mirrors the
+# agent customization shape under the [workflow] namespace.
+
+[workflow]
+
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, arg parsing).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
+activation_steps_prepend = []
+
+# Steps to run after activation but before the workflow begins writing
+# the retroactive entry to pulse_metrics. Overrides append. Use for
+# context-heavy setup such as fetching the original timestamps from an
+# external system (CI logs, time tracker) before reconstruction.
+
+activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (org constants, project-wide standards). Distinct from the runtime
+# memory sidecar — these are static context loaded on activation.
+# Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Backfill only stories from the adoption sprint."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
+
+persistent_facts = []
+
+# Scalar: executed when the workflow has written the retroactive entry to
+# pulse_metrics, confirmed it to the user, and run the optional dashboard
+# refresh. Override wins (e.g. set "/bmad-pulse-dashboard" to always
+# regenerate). Leave empty for no custom post-completion behavior.
+
+on_complete = ""

--- a/skills/bmad-pulse-track-backfill/workflow.md
+++ b/skills/bmad-pulse-track-backfill/workflow.md
@@ -1,0 +1,258 @@
+---
+name: bmad-pulse-track-backfill
+description: 'Retroactively record HI/HF and PULSE metrics for an unmeasured story'
+standalone: true
+main_config: '{project-root}/_bmad/config.yaml'
+config_section: 'pulse'
+---
+
+# Workflow Track Backfill
+
+**Goal:** Reconstruct a complete `pulse_metrics:` entry — start, end, and the
+same leverage/process math `track-done` produces — for a story whose
+`track-start`/`track-done` were never invoked, marking it `retroactive: true`
+for traceability.
+
+**Your Role:** You are Levi, recovering lost measurements with rigor and
+honest provenance. You never disguise reconstructed data as real-time data.
+
+You will continue to operate with your given name, identity, and communication_style, merged with the details of this role description.
+
+## Conventions
+
+- Bare paths (e.g. `customize.toml`) resolve from the skill root.
+- `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives).
+- `{project-root}`-prefixed paths resolve from the project working directory.
+- `{skill-name}` resolves to the skill directory's basename.
+
+## On Activation
+
+### Step 1: Resolve the Workflow Block
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+
+**If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
+
+1. `{skill-root}/customize.toml` — defaults
+2. `{project-root}/_bmad/custom/{skill-name}.toml` — team overrides
+3. `{project-root}/_bmad/custom/{skill-name}.user.toml` — personal overrides
+
+Any missing file is skipped. Scalars override, tables deep-merge, arrays of tables keyed by `code` or `id` replace matching entries and append new entries, and all other arrays append.
+
+### Step 2: Execute Prepend Steps
+
+Execute each entry in `{workflow.activation_steps_prepend}` in order before proceeding.
+
+### Step 3: Load Persistent Facts
+
+Treat every entry in `{workflow.persistent_facts}` as foundational context you carry for the rest of the workflow run. Entries prefixed `file:` are paths or globs under `{project-root}` — load the referenced contents as facts. All other entries are facts verbatim.
+
+### Step 4: Load Config and Execute Append Steps
+
+Load the PULSE configuration as described in INITIALIZATION below, then execute each entry in `{workflow.activation_steps_append}` in order. Activation is complete; begin the workflow EXECUTION section.
+
+---
+
+## INITIALIZATION
+
+### Configuration Loading
+
+Load the `pulse` section from `{main_config}` and resolve module variables:
+
+- `output_folder`, `user_name`, `communication_language`
+- `pulse_data_folder`, `pulse_dashboard_folder`
+- `pulse_sprint_status_filename`
+- `pulse_estimation_method` — `hours` / `story_points` / `tshirt` / `bcp`
+- `pulse_story_point_hours_factor` (story points → hours conversion factor)
+- `pulse_field_estimated_hours`, `pulse_field_dev_count`, `pulse_field_category`
+- `pulse_dev_categories` — list of valid configured categories
+- `pulse_leverage_threshold_exceptional`, `pulse_leverage_threshold_solid`, `pulse_leverage_warning_threshold`
+- `pulse_levi_verbosity`, `pulse_levi_coaching_mode`
+- `date` as current system-generated datetime (ISO 8601)
+
+> **Note on `pulse_estimation_method`:** estimate conversion is identical to
+> `track-done` (see Step 4). For `story_points` the estimate field holds
+> points; for `bcp` PULSE stays **passive and zero-coupled** — it does NOT
+> compute hours from BCP. `bcp` only signals the upstream `estimated_hours`
+> was already derived by [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp);
+> PULSE reads `estimated_hours` exactly as for `hours` and additionally
+> snapshots the read-only `bcp.*` block for audit. PULSE never writes the
+> story frontmatter and never touches the BCP baseline file.
+
+### Paths
+
+- `sprint_status_file` = `{pulse_data_folder}/{pulse_sprint_status_filename}`
+
+---
+
+## EXECUTION
+
+### Step 1: Parse Arguments
+
+Expected invocation:
+
+```text
+/bmad-pulse-track-backfill [story_id] --hi "2026-05-18 14:00" --hf "2026-05-18 15:00"
+```
+
+1. `story_id` — first positional argument (e.g. `1.2`).
+2. `--hi` (HI, hora início) — implementation start, parsed as a local datetime.
+3. `--hf` (HF, hora fim) — implementation end.
+4. Optional `--review-cycles N` — defaults to `1` (first-pass) if omitted; prompt only if not supplied and `pulse_levi_verbosity` is not `concise`.
+5. Optional `--effective-hours H` — overrides the wall-clock derivation when the user already knows the effective AI working time (mirrors `track-done`'s `effective_hours`).
+6. Optional `--note "..."` — free text appended to `retroactive_note`.
+
+Any of `story_id`, `--hi`, `--hf` missing → prompt the user for the missing value(s). Do not invent timestamps.
+
+### Step 2: Validate Inputs
+
+1. Parse `--hi` and `--hf` to ISO 8601 (`YYYY-MM-DDTHH:MM:SS`). Accept `YYYY-MM-DD HH:MM` and ISO forms; reject anything unparseable with a one-line error and exit.
+2. Require `HF > HI`. If `HF <= HI`, error (`⚠ HF must be after HI`) and exit — never write a non-positive duration.
+3. Read `{sprint_status_file}`. If a `pulse_metrics:` entry already exists for `story_id`:
+   - If it has both `start_ts` and `end_ts` and **no** `retroactive: true`, warn: this looks like real-time tracked data — backfilling would overwrite genuine measurements. Ask for explicit confirmation before proceeding.
+   - Otherwise ask whether to overwrite the existing (likely earlier backfill) entry.
+
+### Step 3: Extract Story Data (read-only)
+
+1. Locate the story file in the configured implementation-artifacts folder.
+2. Extract, identically to `track-start`:
+   - the field configured in `pulse_field_estimated_hours` (hours or points per `pulse_estimation_method`)
+   - the field configured in `pulse_field_dev_count`
+   - `task_count` (number of tasks/subtasks)
+   - the field configured in `pulse_field_category` (infer from name; if ambiguous, ask using `pulse_dev_categories`)
+   - the `bcp:` frontmatter block **only if present** (written exclusively by `bmad-module-bcp`):
+     - Read `bcp.schema_version`. If it is anything other than `"1.0"`, emit `⚠ Unknown bcp.schema_version <v> — ignoring bcp.* for this story` and treat the block as absent.
+     - Otherwise capture `bcp.total`, `bcp.rule_version`, `bcp.scored_by`. PULSE does not interpret `bcp.breakdown` or `bcp.history`.
+   - This extraction is **read-only** — PULSE never writes back to the story frontmatter.
+3. If the story file or the estimate field cannot be found, ask the user to supply `estimated_hours` (and `category`) directly rather than aborting — the backfill's purpose is to recover otherwise-lost data.
+
+### Step 4: Calculate Metrics
+
+Estimate conversion is identical to `track-done`:
+
+- `story_points` → `estimated_hours = points * pulse_story_point_hours_factor`
+- `tshirt` → S=2h, M=4h, L=8h, XL=16h
+- `hours` → value used directly
+- `bcp` → value used directly (already derived upstream by `bmad-module-bcp`; PULSE does NOT compute hours from BCP — it consumes the field as-is, identical to the `hours` branch)
+
+Leverage:
+
+```text
+elapsed_minutes = (HF - HI) in minutes
+actual_hours    = effective_hours ?? max(0.01, elapsed_minutes / 60)
+leverage_ratio  = estimated_hours / actual_hours
+first_pass      = review_cycles == 1
+```
+
+There is no halt subtraction in backfill — halts are real-time-only signal that
+cannot be reconstructed honestly after the fact. If the user supplied
+`--effective-hours`, it wins (they already corrected for non-dev time);
+otherwise `actual_hours` is the raw `HF − HI` wall-clock, floored at 0.01h to
+avoid divide-by-zero.
+
+**BCP productivity (only when a BCP total is available):** resolve `bcp_total`
+from the `bcp.*` block captured in Step 3. If absent, skip this block entirely.
+When `bcp_total` is a positive number:
+
+```text
+h_per_bcp_actual    = round(actual_hours    / bcp_total, 2)
+h_per_bcp_estimated = round(estimated_hours / bcp_total, 2)
+drift_pct           = round((h_per_bcp_actual - h_per_bcp_estimated)
+                            / h_per_bcp_estimated * 100, 1)   # 0.0 if estimated == 0
+```
+
+PULSE does **not** update any BCP baseline — baseline maturation is the
+`bmad-module-bcp` module's responsibility (via `/bmad-bcp-recalibrate`).
+
+### Step 5: Write the Retroactive Entry
+
+In the `pulse_metrics:` section of `{sprint_status_file}`, create or overwrite
+the entry for `story_id`. **Shape note:** PULSE stores `pulse_metrics` as a
+**mapping keyed by story id** (same shape `track-start`/`track-done` write and
+the dashboard reads), not a list. Use that canonical shape so the entry is
+readable by every other PULSE skill:
+
+```yaml
+pulse_metrics:
+  "1.2":
+    start_ts: "2026-05-18T14:00:00"
+    end_ts: "2026-05-18T15:00:00"
+    estimated_hours: 103
+    dev_count: 1
+    task_count: 4
+    category: backend
+    actual_hours: 1.0          # retroactive backfill: HF 15:00 - HI 14:00
+    review_cycles: 1
+    leverage_ratio: 103.0
+    first_pass: true
+    retroactive: true
+    retroactive_note: "Data inserted manually via track-backfill — TS/TD not invoked in the original cycle"
+```
+
+Rules:
+
+1. `retroactive: true` is **mandatory and non-negotiable** on every entry this
+   skill writes. Never omit it, never set it to `false`. It is the provenance
+   marker that lets the dashboard and any consumer distinguish reconstructed
+   data from real-time measurement.
+2. `retroactive_note` always records that TS/TD were not invoked in the
+   original cycle. Append the user's `--note` text when provided.
+3. Annotate `actual_hours` with a YAML comment showing the HI/HF derivation
+   (or `effective_hours override` when `--effective-hours` was supplied) so the
+   math stays traceable.
+4. **BCP snapshot (only when a valid `bcp:` block was captured):** add
+   `estimation_basis: <method>`, `bcp_at_start:` (`total`, `rule_version`,
+   `scored_by`), and `bcp_recorded:` (`total`, `h_per_bcp_actual`,
+   `h_per_bcp_estimated`, `drift_pct`). When no valid `bcp:` block is present,
+   omit all BCP fields entirely.
+5. Do not write `process_health` — flow/halt/skill checks require real-time
+   observation `track-done` performs live. Backfill deliberately leaves
+   `process_health` absent; readers already treat it as optional.
+
+### Step 6: Confirm
+
+Display (respect `pulse_levi_verbosity`):
+
+```text
+⚡ Levi: Backfill recorded — RETROACTIVE entry for story {story_id}
+   ⚠ Reconstructed data — TS/TD were not run in the original cycle.
+
+   HI: {start_ts}  →  HF: {end_ts}
+   Human estimate: {estimated_hours}h ({dev_count} devs)
+   Actual AI time: {actual_hours}h ({elapsed_minutes}min wall-clock)
+   AI Leverage: {leverage_ratio}x
+   {if bcp_recorded}BCP: {bcp_recorded.total} pts | {bcp_recorded.h_per_bcp_actual}h/BCP actual vs {bcp_recorded.h_per_bcp_estimated}h/BCP est ({bcp_recorded.drift_pct:+}% drift){end}
+   Quality: {first_pass ? "✅ first-pass" : "🔄 " + review_cycles + " cycles"}
+   Category: {category}
+   {leverage_ratio >= pulse_leverage_threshold_exceptional ? "🔥 Exceptional!" : leverage_ratio >= pulse_leverage_threshold_solid ? "💪 Solid!" : leverage_ratio < pulse_leverage_warning_threshold ? "⚠ Below expectations — review estimates." : "📊 Data recorded."}
+
+   💡 {if pulse_levi_coaching_mode == yes}Run /bmad-pulse-track-start and /bmad-pulse-track-done on future stories to capture process health and halts, which backfill cannot reconstruct.{end}
+```
+
+### Step 7: Offer Dashboard Refresh
+
+Ask the user (default yes unless `pulse_levi_verbosity` is `concise`, in which
+case proceed without prompting): "Regenerate the PULSE dashboard now to include
+this story?" If yes, invoke the `bmad-pulse-dashboard` skill. Consumers who
+want this unconditional can set it in `{workflow.on_complete}` instead.
+
+---
+
+## BEHAVIOR RESTRICTIONS
+
+- DO NOT modify anything outside the `pulse_metrics:` section of `{sprint_status_file}`
+- DO NOT write to the story file frontmatter or to any BCP baseline file (`bcp-baseline.yaml`) — `bcp.*` is read-only input owned by `bmad-module-bcp`; baseline recalibration lives in that module
+- Every entry this skill writes MUST carry `retroactive: true` — backfilled data is never presented as real-time data
+- Never reconstruct `process_health` or halts — those require live observation; leave them absent
+- If a real-time-tracked entry (has `start_ts`+`end_ts`, no `retroactive` flag) already exists for the story, require explicit confirmation before overwriting
+- Create the `pulse_metrics:` section if it does not exist
+- Communicate in the language configured in `communication_language`
+
+---
+
+## On Completion
+
+After Step 6 (Confirm) has displayed the recorded entry and the optional
+dashboard refresh in Step 7 has run, execute the `{workflow.on_complete}`
+scalar if non-empty. Override wins; an empty value means no custom
+post-completion behavior.

--- a/tests/test_backfill_invariants.py
+++ b/tests/test_backfill_invariants.py
@@ -1,0 +1,122 @@
+"""Invariant tests for the bmad-pulse-track-backfill skill.
+
+Issue #41: PULSE can retroactively reconstruct a `pulse_metrics:` entry for a
+story whose track-start/track-done were never invoked (early-adoption stories,
+workflow interruptions), marking it `retroactive: true` for traceability.
+
+These are meta/invariant tests in the same spirit as
+``test_bcp_integration.py`` — they pin the provenance and loose-coupling
+contract in the workflow markdown so a future edit cannot silently let
+backfill masquerade reconstructed data as real-time data, or start writing
+the story frontmatter / BCP baseline.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import tomlkit
+import yaml
+
+REPO_ROOT = Path(__file__).parents[1]
+SKILL_DIR = REPO_ROOT / "skills/bmad-pulse-track-backfill"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+WORKFLOW = SKILL_DIR / "workflow.md"
+CUSTOMIZE = SKILL_DIR / "customize.toml"
+MARKETPLACE = REPO_ROOT / ".claude-plugin/marketplace.json"
+MODULE_HELP = REPO_ROOT / "skills/bmad-pulse-setup/assets/module-help.csv"
+AGENT_CUSTOMIZE = REPO_ROOT / "skills/bmad-agent-pulse/customize.toml"
+AGENT_SKILL = REPO_ROOT / "skills/bmad-agent-pulse/SKILL.md"
+DOCS_INDEX = REPO_ROOT / "docs/index.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    parts = path.read_text().split("---", 2)
+    return yaml.safe_load(parts[1]) if len(parts) >= 3 else {}
+
+
+def test_skill_folder_and_frontmatter_name():
+    assert SKILL_MD.exists(), "skills/bmad-pulse-track-backfill/SKILL.md must exist"
+    assert WORKFLOW.exists(), "workflow.md must exist"
+    for path in (SKILL_MD, WORKFLOW):
+        assert _frontmatter(path)["name"] == "bmad-pulse-track-backfill"
+
+
+def test_workflow_accepts_hi_hf_arguments():
+    """The skill's whole purpose: take --hi / --hf and a story id."""
+    text = WORKFLOW.read_text()
+    assert "--hi" in text and "--hf" in text
+    assert "story_id" in text
+
+
+def test_actual_hours_derived_from_hi_hf():
+    """actual_hours must be reconstructed from the HI/HF span, not invented."""
+    text = WORKFLOW.read_text()
+    assert "elapsed_minutes = (HF - HI)" in text
+    assert "actual_hours" in text and "leverage_ratio  = estimated_hours / actual_hours" in text
+
+
+def test_retroactive_flag_is_mandatory():
+    """retroactive: true is the provenance marker — it must be asserted as
+    mandatory and non-negotiable, so reconstructed data is never disguised
+    as real-time measurement."""
+    text = WORKFLOW.read_text()
+    assert "retroactive: true" in text
+    assert "retroactive_note" in text
+    assert "mandatory and non-negotiable" in text
+    # Must NOT fabricate process_health (halts/flow are live-only signal).
+    assert "Never reconstruct `process_health`" in text
+
+
+def test_pulse_never_writes_story_frontmatter_or_baseline():
+    """Loose-coupling contract identical to track-start/track-done: read-only
+    on story frontmatter, never the BCP baseline."""
+    text = WORKFLOW.read_text()
+    assert "baseline" in text.lower()
+    assert "read-only" in text.lower() or "DO NOT write" in text
+    assert "DO NOT modify anything outside the `pulse_metrics:` section" in text
+
+
+def test_workflow_documents_canonical_mapping_shape():
+    """Issue #41 illustrated a list shape; PULSE canonically stores
+    pulse_metrics as a mapping keyed by story id. The deviation must be
+    documented so the entry stays readable by every other PULSE skill."""
+    text = WORKFLOW.read_text()
+    assert "mapping keyed by story id" in text
+
+
+def test_customize_toml_surface():
+    data = tomlkit.loads(CUSTOMIZE.read_text())
+    assert "DO NOT EDIT" in CUSTOMIZE.read_text().splitlines()[0].upper()
+    wf = data["workflow"]
+    for key in ("activation_steps_prepend", "activation_steps_append", "persistent_facts"):
+        assert isinstance(wf[key], list), f"{key} must be a list"
+    assert isinstance(wf["on_complete"], str)
+
+
+def test_marketplace_lists_backfill_skill():
+    data = json.loads(MARKETPLACE.read_text())
+    skills = data["plugins"][0]["skills"]
+    assert "./skills/bmad-pulse-track-backfill" in skills
+    assert SKILL_DIR.is_dir()
+
+
+def test_module_help_registers_backfill():
+    rows = list(csv.DictReader(MODULE_HELP.read_text().splitlines()))
+    backfill = [r for r in rows if r["skill"] == "bmad-pulse-track-backfill"]
+    assert len(backfill) == 1, "module-help.csv must register bmad-pulse-track-backfill exactly once"
+    assert backfill[0]["menu-code"] == "TB"
+
+
+def test_agent_menu_exposes_backfill():
+    data = tomlkit.loads(AGENT_CUSTOMIZE.read_text())
+    skills = [m.get("skill") for m in data["agent"]["menu"]]
+    assert "bmad-pulse-track-backfill" in skills
+    assert "bmad-pulse-track-backfill" in AGENT_SKILL.read_text()
+
+
+def test_docs_index_documents_backfill():
+    text = DOCS_INDEX.read_text()
+    assert "bmad-pulse-track-backfill" in text
+    assert "retroactive" in text

--- a/tests/test_customize_toml_surface.py
+++ b/tests/test_customize_toml_surface.py
@@ -28,6 +28,7 @@ WORKFLOW_SKILLS = [
     "bmad-pulse-setup",
     "bmad-pulse-track-start",
     "bmad-pulse-track-done",
+    "bmad-pulse-track-backfill",
     "bmad-pulse-dashboard",
 ]
 
@@ -115,6 +116,9 @@ def test_agent_customize_has_required_keys(skill: str):
         ("bmad-pulse-track-done", "activation_steps_prepend"),
         ("bmad-pulse-track-done", "activation_steps_append"),
         ("bmad-pulse-track-done", "persistent_facts"),
+        ("bmad-pulse-track-backfill", "activation_steps_prepend"),
+        ("bmad-pulse-track-backfill", "activation_steps_append"),
+        ("bmad-pulse-track-backfill", "persistent_facts"),
         ("bmad-pulse-dashboard", "activation_steps_prepend"),
         ("bmad-pulse-dashboard", "activation_steps_append"),
         ("bmad-pulse-dashboard", "persistent_facts"),
@@ -131,7 +135,7 @@ def test_workflow_arrays_are_arrays(skill: str, array_key: str):
     )
 
 
-@pytest.mark.parametrize("skill", ["bmad-pulse-track-start", "bmad-pulse-track-done", "bmad-pulse-dashboard"])
+@pytest.mark.parametrize("skill", ["bmad-pulse-track-start", "bmad-pulse-track-done", "bmad-pulse-track-backfill", "bmad-pulse-dashboard"])
 def test_workflow_on_complete_is_scalar_string(skill: str):
     """on_complete is the terminal hook — must be a string scalar so
     override semantics (override wins) work. Setup is exempt: it is a


### PR DESCRIPTION
Closes #41.

## Problem

PULSE assumes track-start/track-done run during the story lifecycle. When they don't (early-adoption stories, workflow interruptions), there was no mechanism to record the real data after the fact. Real case (story 1.2): market-benchmark dashboard reported 4.1x leverage; with real HI/HF (1h vs 103h estimate) the true ratio was 103x.

## Solution

New skill `bmad-pulse-track-backfill`.

```
/bmad-pulse-track-backfill 1.2 --hi "2026-05-18 14:00" --hf "2026-05-18 15:00"
```

- Accepts `[story_id] --hi/--hf` (+ optional `--review-cycles`, `--effective-hours`, `--note`); `actual_hours = HF - HI`
- Reuses track-done leverage/BCP math; BCP stays passive and zero-coupled (no hours computed from BCP, no baseline/frontmatter writes)
- Every backfilled entry carries **mandatory `retroactive: true`** + `retroactive_note` for provenance — reconstructed data is never presented as real-time measurement
- `process_health` deliberately omitted: halts/BMAD flow cannot be reconstructed honestly after the fact
- Optional dashboard refresh (Step 7) + `on_complete` hook

## Wire-up

marketplace.json, module-help.csv (`TB`), Levi agent menu (`BF`) + capabilities table, README / README.pt-BR, docs/index.md.

## Tests

`tests/test_backfill_invariants.py` (11 invariants pinning the retroactive + loose-coupling contract) + parametrized into `test_customize_toml_surface`. Full suite **114 passed**.

## Design note

Issue #41 illustrated a list shape for `pulse_metrics`. PULSE canonically stores it as a **mapping keyed by story id** (same shape track-start/done/dashboard read and write). The list shape would break every other PULSE reader, so the canonical mapping shape is used; the deviation is documented in the workflow and pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)