### PR TITLE
fix(setup): make track-start auto-trigger an executed activation step

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,37 @@ python3 .claude/skills/bmad-pulse-setup/scripts/reconcile-skills.py \
 
 ---
 
+## Auto-tracking fix — regenerate the `bmad-dev-story` override (post-v0.4.9)
+
+If `bmad-pulse-track-start` was **not firing automatically** at the start of
+your stories (issue #47), the cause was the auto-tracking trigger living in
+the `persistent_facts` array of `_bmad/custom/bmad-dev-story.toml`.
+`persistent_facts` is passive context the agent merely carries — it did not
+deterministically execute. The fix moves the trigger to
+`activation_steps_append` (an executed activation step) and decouples it from
+the sprint-status `in-progress` field.
+
+The fix ships in the PULSE source, but **existing installs keep the old
+override file**: `bmad-pulse-setup` aborts rather than overwrite a file you
+may have customized. To pick up the fix, regenerate it:
+
+```bash
+# 1. Pull the new PULSE version
+npx bmad-method install --custom-source https://github.com/nidelson/bmad-module-pulse
+
+# 2. Remove the stale override (or back it up if you customized it)
+rm _bmad/custom/bmad-dev-story.toml
+
+# 3. Re-run setup — it re-emits the override with the activation-step trigger
+/bmad-pulse-setup
+```
+
+Alternatively, re-run setup and let it overwrite via `--force` (passed through
+to `inject_customize.py`). `bmad-code-review.toml` (track-done) is unchanged —
+only the `bmad-dev-story` override needs regeneration.
+
+---
+
 ## v0.4.4 → v0.4.5 — Levi agent consolidation
 
 v0.4.5 consolidates the Levi agent into a single canonical skill folder
@@ -188,7 +219,7 @@ git commit -m "chore(pulse): migrate to v0.4.0 customize.toml integration"
 
 | Before (v0.3.x) | After (v0.4.0) |
 |---|---|
-| `<!-- PULSE:auto-inject -->` markers in `.claude/skills/bmad-dev-story/workflow.md` | `_bmad/custom/bmad-dev-story.toml` (track-start in `persistent_facts`) |
+| `<!-- PULSE:auto-inject -->` markers in `.claude/skills/bmad-dev-story/workflow.md` | `_bmad/custom/bmad-dev-story.toml` (track-start auto-trigger) |
 | Track-done injected at end of `bmad-dev-story` workflow | `_bmad/custom/bmad-code-review.toml` (track-done in `on_complete`) |
 | Auto-tracking broken silently on every BMAD ≥6.4.0 install | Auto-tracking survives BMAD core upgrades |
 

--- a/skills/bmad-pulse-setup/assets/customize-templates/bmad-dev-story.toml
+++ b/skills/bmad-pulse-setup/assets/customize-templates/bmad-dev-story.toml
@@ -4,12 +4,15 @@
 # `/bmad-pulse-setup` aborts when this file already exists; pass `--force` to
 # regenerate, which overwrites your edits.
 #
-# The instructions below are read by the BMAD agent invoking the
-# `bmad-dev-story` workflow. They are merged into the workflow's
-# `persistent_facts` (append semantics).
+# The step below is appended to the `bmad-dev-story` workflow's
+# `activation_steps_append` (append semantics) — an EXECUTED activation step,
+# not passive context. It runs after greet and before the workflow begins, so
+# track-start fires deterministically at the start of every implementation.
+# (Previously this lived in `persistent_facts`, which is passive context the
+# agent merely carries — it did not reliably trigger. See issue #47.)
 
 [workflow]
 
-persistent_facts = [
-  "PULSE auto-tracking enabled. After workflow Step 1 identifies the in-progress story (resolving its story_id from sprint-status.yaml or the explicit {story_path}), invoke the bmad-pulse-track-start skill, passing the story_id as argument (e.g. /bmad-pulse-track-start 15.3) BEFORE starting implementation. The skill is idempotent — if a start_ts already exists in pulse_metrics: for this story, it asks before overwriting. Skip the invocation for read-only or exploratory stories without real implementation.",
+activation_steps_append = [
+  "PULSE auto-tracking: invoke the bmad-pulse-track-start skill BEFORE implementation begins. Resolve the story_id from the story this bmad-dev-story run is about to implement — the story file / {story_path} the workflow was given — NOT from the sprint-status `in-progress` field, since the story may still be `ready-for-dev` at this point. Pass the story_id explicitly, e.g. /bmad-pulse-track-start 15.3. The skill is idempotent — if a start_ts already exists in pulse_metrics: for this story, it asks before overwriting. Skip the invocation only for read-only or exploratory stories without real implementation.",
 ]

--- a/skills/bmad-pulse-track-start/workflow.md
+++ b/skills/bmad-pulse-track-start/workflow.md
@@ -86,10 +86,18 @@ Load the `pulse` section from `{main_config}` and resolve module variables:
 
 ### Step 1: Identify Story
 
-1. If arguments were passed (e.g. `15.3`), use them as the story ID
-2. If not, read `{sprint_status_file}` and identify stories with status `in-progress`
-3. If multiple stories in-progress, ask the user which one to record
-4. If no story in-progress, inform and exit
+1. **Explicit story id — preferred path (this is how auto-tracking invokes the skill).**
+   If an argument was passed (e.g. `15.3`), or a story id / story file path is
+   available from the invoking context, use it as the story ID directly. Do
+   **not** require the story to be marked `in-progress` in sprint-status —
+   track-start fires at implementation start, when the story may still be
+   `ready-for-dev`. The sprint-status status field is not a precondition.
+2. **Fallback — no story id available (manual no-argument invocation).** Read
+   `{sprint_status_file}` and identify stories with status `in-progress`.
+3. If exactly one story is `in-progress`, use it.
+4. If multiple stories are `in-progress`, ask the user which one to record.
+5. If no story is `in-progress`, do **not** silently exit — ask the user for the
+   story id (the story may simply not have been transitioned to `in-progress` yet).
 
 ### Step 2: Extract Story Data
 

--- a/tests/fixtures/golden/customize-bmad-dev-story.toml
+++ b/tests/fixtures/golden/customize-bmad-dev-story.toml
@@ -4,12 +4,15 @@
 # `/bmad-pulse-setup` aborts when this file already exists; pass `--force` to
 # regenerate, which overwrites your edits.
 #
-# The instructions below are read by the BMAD agent invoking the
-# `bmad-dev-story` workflow. They are merged into the workflow's
-# `persistent_facts` (append semantics).
+# The step below is appended to the `bmad-dev-story` workflow's
+# `activation_steps_append` (append semantics) — an EXECUTED activation step,
+# not passive context. It runs after greet and before the workflow begins, so
+# track-start fires deterministically at the start of every implementation.
+# (Previously this lived in `persistent_facts`, which is passive context the
+# agent merely carries — it did not reliably trigger. See issue #47.)
 
 [workflow]
 
-persistent_facts = [
-  "PULSE auto-tracking enabled. After workflow Step 1 identifies the in-progress story (resolving its story_id from sprint-status.yaml or the explicit {story_path}), invoke the bmad-pulse-track-start skill, passing the story_id as argument (e.g. /bmad-pulse-track-start 15.3) BEFORE starting implementation. The skill is idempotent — if a start_ts already exists in pulse_metrics: for this story, it asks before overwriting. Skip the invocation for read-only or exploratory stories without real implementation.",
+activation_steps_append = [
+  "PULSE auto-tracking: invoke the bmad-pulse-track-start skill BEFORE implementation begins. Resolve the story_id from the story this bmad-dev-story run is about to implement — the story file / {story_path} the workflow was given — NOT from the sprint-status `in-progress` field, since the story may still be `ready-for-dev` at this point. Pass the story_id explicitly, e.g. /bmad-pulse-track-start 15.3. The skill is idempotent — if a start_ts already exists in pulse_metrics: for this story, it asks before overwriting. Skip the invocation only for read-only or exploratory stories without real implementation.",
 ]

--- a/tests/test_auto_tracking_trigger.py
+++ b/tests/test_auto_tracking_trigger.py
@@ -1,0 +1,86 @@
+"""Regression tests for issue #47: PULSE auto-tracking trigger wiring.
+
+`track-start` failed to fire automatically because its trigger lived in the
+`persistent_facts` array of the `bmad-dev-story` override — passive context
+the BMAD agent merely carries, not an executed step. `track-done`, wired in
+`on_complete` (an active hook), worked fine.
+
+These tests pin the asymmetry fix: the track-start trigger must live in an
+*executed* customize array (`activation_steps_*`), never only in
+`persistent_facts`; track-done must stay on the active `on_complete` hook.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomlkit
+
+REPO_ROOT = Path(__file__).parents[1]
+TEMPLATES = REPO_ROOT / "skills/bmad-pulse-setup/assets/customize-templates"
+DEV_STORY_TMPL = TEMPLATES / "bmad-dev-story.toml"
+CODE_REVIEW_TMPL = TEMPLATES / "bmad-code-review.toml"
+TRACK_START_WF = REPO_ROOT / "skills/bmad-pulse-track-start/workflow.md"
+
+
+def _workflow(path: Path) -> dict:
+    return tomlkit.loads(path.read_text())["workflow"]
+
+
+def test_track_start_trigger_is_an_executed_activation_step():
+    """The track-start trigger must live in activation_steps_append /
+    _prepend — arrays the BMAD agent EXECUTES — so it fires deterministically."""
+    wf = _workflow(DEV_STORY_TMPL)
+    steps = list(wf.get("activation_steps_append", [])) + list(
+        wf.get("activation_steps_prepend", [])
+    )
+    assert any("bmad-pulse-track-start" in s for s in steps), (
+        "bmad-dev-story.toml must invoke bmad-pulse-track-start from an "
+        "activation_steps_* array (executed), not from passive context."
+    )
+
+
+def test_track_start_trigger_not_in_passive_persistent_facts():
+    """Passive `persistent_facts` is the bug from #47 — the track-start
+    trigger must not regress back into it."""
+    wf = _workflow(DEV_STORY_TMPL)
+    facts = wf.get("persistent_facts", [])
+    assert not any("bmad-pulse-track-start" in str(f) for f in facts), (
+        "bmad-dev-story.toml persistent_facts must NOT carry the track-start "
+        "trigger — persistent_facts is passive context, it does not execute "
+        "(issue #47)."
+    )
+
+
+def test_track_start_trigger_decoupled_from_in_progress_status():
+    """The trigger must resolve the story from the story file/path, not from
+    the sprint-status `in-progress` field (the story may still be ready-for-dev)."""
+    wf = _workflow(DEV_STORY_TMPL)
+    steps = " ".join(wf.get("activation_steps_append", []))
+    assert "in-progress" in steps and "NOT" in steps, (
+        "the track-start trigger must explicitly state it does NOT depend on "
+        "the sprint-status in-progress field"
+    )
+
+
+def test_track_done_stays_on_active_on_complete_hook():
+    """track-done was never broken — pin that it stays on the active
+    on_complete hook so a future edit cannot make it passive too."""
+    wf = _workflow(CODE_REVIEW_TMPL)
+    on_complete = wf.get("on_complete", "")
+    assert "bmad-pulse-track-done" in on_complete, (
+        "bmad-code-review.toml must invoke bmad-pulse-track-done from on_complete"
+    )
+
+
+def test_track_start_skill_does_not_hard_exit_without_in_progress_story():
+    """track-start Step 1 must not silently exit when no story is in-progress —
+    it should prefer an explicit story id and otherwise ask the user."""
+    text = TRACK_START_WF.read_text()
+    assert "inform and exit" not in text, (
+        "track-start Step 1 must not silently 'inform and exit' on a missing "
+        "in-progress story — that dead-ends the auto-tracking path (issue #47)."
+    )
+    assert "ready-for-dev" in text, (
+        "track-start Step 1 should acknowledge a story may still be "
+        "`ready-for-dev` when track-start fires."
+    )


### PR DESCRIPTION
Closes #47.

## Problem

PULSE auto-tracking fired `track-done` reliably but **not `track-start`**. Detected by field validation on a real BMAD 6.7.x project (CI&T): 2 stories implemented via `/bmad-dev-story`, track-start fired in neither.

## Root cause

**A — asymmetry: action modelled as passive context.**

| Trigger | Wired via | Type |
|---|---|---|
| track-done | `on_complete` of `bmad-code-review` | active hook — agent **executes** it |
| track-start | `persistent_facts` of `bmad-dev-story` | passive context — agent merely **carries** it |

`persistent_facts` is foundational context, not an executed step; whether the agent invoked track-start was left to LLM discretion. `bmad-dev-story`'s customize surface exposes `activation_steps_append` (executed — "runs after greet, before the workflow begins") — that was the correct integration point.

**C — coupling to sprint-status `in-progress`.**

The passive fact was gated on _"After Step 1 identifies the **in-progress** story"_, and `bmad-pulse-track-start` Step 1's no-arg path exits silently when no story is `in-progress`. A story still in `ready-for-dev` (sprint flow not transitioned) broke the chain at both points.

**B — discarded.** `bmad-dev-story` and `bmad-code-review` still exist as skills in BMAD 6.7.x — the override targets are valid.

## Fix

- **`bmad-dev-story.toml` template** — move the track-start trigger from `persistent_facts` to `activation_steps_append` (executed step → deterministic).
- The trigger resolves `story_id` from the story `bmad-dev-story` is implementing (story file / `{story_path}`) and passes it explicitly — no longer depends on the sprint-status `in-progress` field.
- **`bmad-pulse-track-start` workflow Step 1** — explicit story id is the preferred path, not gated on `in-progress`; the no-arg fallback asks the user instead of silently exiting.
- Regenerated golden fixture `customize-bmad-dev-story.toml`.
- **MIGRATION.md** — section explaining existing installs must regenerate `_bmad/custom/bmad-dev-story.toml` (`bmad-pulse-setup` aborts rather than overwrite an existing override).

`track-done` is unchanged — `on_complete` of `bmad-code-review` is the correct hook.

## Regression test

`tests/test_auto_tracking_trigger.py` (5 tests): pins the track-start trigger to an executed `activation_steps_*` array, forbids it regressing into `persistent_facts`, pins decoupling from `in-progress`, pins track-done staying on the active `on_complete` hook. Full suite: **122 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)