### PR TITLE
feat(dashboard)!: v0.5 engine de medição honesto (média geométrica, segmentação, faixa de confiança, anti-Goodhart)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,55 @@ python3 .claude/skills/bmad-pulse-setup/scripts/reconcile-skills.py \
 
 ---
 
+## v0.4.x → v0.5.0 — Honest measurement engine (BCP dashboard)
+
+**Who this affects:** only projects using `pulse_estimation_method=bcp`. If you
+do not use BCP, the dashboard is unchanged — skip this section.
+
+v0.5.0 reworks how the dashboard summarizes per-category **h/BCP** so the number
+is honest rather than flattering. Nothing about tracking, frontmatter, or the
+BCP module boundary changes — PULSE stays passive and zero-coupled to
+`bmad-module-bcp` (it still only *reads* `bcp.*`, never writes a baseline). The
+shift is entirely in how the **BCP Productivity** section is computed and
+rendered.
+
+### What changes
+
+- **Geometric mean, not arithmetic.** Per-category h/BCP baselines are now the
+  *geometric* mean of the per-story ratios (`exp(mean(ln(ratio)))`). h/BCP is a
+  multiplicative ratio, so the arithmetic mean was biased high and fragile to a
+  single outlier. **Baselines recomputed from the same data will shift** — this
+  is the intended correction, not a regression.
+- **Micro vs story-size segmentation.** Stories are split at the *observed
+  median* BCP total (`micro` below, `story` at/above) and each segment gets its
+  own baseline, so a 1-point fix no longer pollutes a 40-point story's number. A
+  pooled `all` row remains for continuity. The split is data-driven — PULSE
+  makes no assumption about your BCP point scale and there is **no new config
+  key**.
+- **Confidence band, not a point.** Each baseline now shows a *typical range*
+  `[low–high]` (geometric standard deviation, ~68%) plus the sample size `n`.
+  Ranges appear only at `n >= 3`; thinner samples show the bare point.
+- **Leverage reframed (anti-Goodhart).** A new dashboard note states that
+  leverage (`estimated_hours / actual_hours`) collapses to ~1.0x once the
+  estimate basis is calibrated — so a *high* multiplier signals an uncalibrated
+  estimate, not velocity, and the durable signal is **predictability** (h/BCP
+  drift converging on zero). The hero-metric inversion itself lands in v0.6;
+  v0.5 only locks the invariant.
+
+### What you must do
+
+**Nothing on disk** beyond a normal upgrade (`/bmad-pulse-setup`). The change is
+in the dashboard workflow; the next `/bmad-pulse-dashboard` run renders the new
+shape. There is no data migration — historical `pulse_metrics` are re-read and
+re-summarized in place.
+
+> ⚠ **Breaking only for tooling that parses the dashboard markdown.** The
+> **BCP Productivity** table gained `Segment` and `n` columns and the h/BCP cell
+> now carries a `[low–high]` range. If you scrape the dashboard, update your
+> parser. The human-readable dashboard and all non-BCP sections are unaffected.
+
+---
+
 ## Auto-tracking fix — regenerate the `bmad-dev-story` override (post-v0.4.9)
 
 If `bmad-pulse-track-start` was **not firing automatically** at the start of

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -94,11 +94,14 @@ Load the `pulse` section from `{main_config}` and resolve all module variables:
        - `legacy_halt_string_count` — count of Shape C entries encountered (used to surface migration hint in insights)
        - `stories_with_approval_wait` — list of `(story_id, total_minutes)` pairs for the breakdown table (entries with unknown minutes show as `?min`)
    - **BCP aggregations** (read `bcp_recorded` and `bcp_at_start` / `estimation_basis` from each story; all optional — a story without them is normal and contributes nothing):
+     - _Since v0.5.0, per-category h/BCP baselines use the **geometric** mean of the per-story ratios, not the arithmetic mean (pre-0.5.0). Baselines recomputed from the same data will shift; this is intentional — see the v0.5 honest-measurement-engine notes._
      - `bcp_stories` — list of stories that have a `bcp_recorded` block
      - `total_bcp` — sum of `bcp_recorded.total` across `bcp_stories`
      - `bcp_throughput` — `total_bcp` grouped by epic (proxy for BCP/sprint when sprint segmentation is unavailable)
-     - `h_per_bcp_by_category` — for each category in `{pulse_dev_categories}`, the mean of `bcp_recorded.h_per_bcp_actual` over its `bcp_stories`
-     - `h_per_bcp_estimated_by_category` — same, over `bcp_recorded.h_per_bcp_estimated` (for the drift comparison)
+     - `segment_split` — the **median** of `bcp_recorded.total` over **all** `bcp_stories` (one global value). Computed **only when `bcp_stories` is non-empty** — never evaluate `median([])`. A story is `micro` when `bcp_recorded.total < segment_split`, else `story`. This split is data-driven: PULSE assumes nothing about the BCP point scale and stays zero-coupled to BCP. (Since v0.5.0.)
+     - `h_per_bcp_by_category` — for each `(category, segment)` with `segment ∈ {micro, story}`, the **geometric mean** of `bcp_recorded.h_per_bcp_actual` over the `bcp_stories` in that category and segment: `exp(mean(ln(h_per_bcp_actual)))`, equivalently `(∏ h_per_bcp_actual)^(1/n)`. h/BCP values are multiplicative ratios, so the geometric mean is the unbiased central tendency and resists outliers (a single 10x story does not drag the baseline the way an arithmetic mean would). Round to 2 decimals. Also compute a per-category **pooled** baseline (`all` segment — geometric mean over every `bcp_story` in the category, ignoring the split) for the continuity row. **Thin-segment fallback:** a `(category, segment)` pair with `n < 3` is not reported on its own; those stories still count in the category's pooled `all` baseline. `n == 0` → pair omitted.
+     - `h_per_bcp_estimated_by_category` — same **geometric mean**, segmented the same way (per `(category, segment)` plus pooled `all`), over `bcp_recorded.h_per_bcp_estimated` (for the drift comparison).
+     - `h_per_bcp_band` — for each baseline (every `(category, segment)` and each pooled `all`), a **confidence band** around the geometric mean of `bcp_recorded.h_per_bcp_actual`, so the baseline reads as a range, not false precision. Compute the **sample geometric standard deviation** `GSD = exp(sample_std(ln(h_per_bcp_actual)))`, where `sample_std` uses the `n-1` (sample, not population) denominator — we estimate, not enumerate. The band is `[geo_mean / GSD, geo_mean * GSD]` (multiplier `k = 1`, ≈ 68% of a log-normal sample — a **typical range**, not a 95% CI; with PULSE's small `n` a wider band would be unactionable). **Require `n >= 3` to emit a band**; for `n < 3` emit the point with an explicit `(n=2)` / `(n=1)` marker and no interval (a GSD from 2 samples has 1 degree of freedom — one outlier distorts it). Carry `n` alongside every baseline so thin samples are visible. (Since v0.5.0.)
      - `drift_trend` — ordered list of `(story_id, bcp_recorded.drift_pct)` for `bcp_stories` (story-order = chronological proxy)
      - `top_bcp_stories` — `bcp_stories` sorted by `bcp_recorded.total` desc, top 5 (proxy for "elements driving BCP" — PULSE does not read `bcp.breakdown`, so it ranks by total points per story)
 
@@ -126,6 +129,8 @@ For `markdown` format (default), write `{dashboard_file}` with the following str
 | Actual AI hours         | {total_actual}h    |
 | Hours saved             | {saved}h           |
 | First-pass rate         | {rate}%            |
+
+> **Anti-Goodhart invariant — leverage is not a target.** `leverage = estimated_hours / actual_hours`. Once the estimate basis is calibrated (estimates derived from a baseline that matches reality), this ratio collapses to **~1.0x by construction** — so a *high* multiplier signals an inflated or uncalibrated estimate basis, **not** velocity, and a *leverage goal* would literally reward never calibrating. The durable signal is **predictability**: the per-category h/BCP drift converging on zero (do estimates match outcomes?). Read every multiplier as "vs PLAN", never "vs human". (The hero-metric inversion lands in v0.6; v0.5 only locks this invariant.)
 
 <!-- CONDITIONAL: include only if pulse_include_trend_chart == yes -->
 ## 📈 Leverage Trend by Epic
@@ -201,12 +206,19 @@ Based on avg leverage of {avg}x:
 Epic {N}: {bcp} BCP ({count} stories)
 {end}
 
-**Actual h/BCP by category:**
+**Actual h/BCP by category and size segment:**
 
-| Category | Actual h/BCP | Est. h/BCP | Drift |
-| -------- | ------------ | ---------- | ----- |
+> Stories split at the observed median BCP (`segment_split` = {segment_split} BCP): below it = `micro`, at/above = `story`. The `all` row pools both, for continuity with pre-0.5 dashboards. A segment with fewer than 3 stories is folded into `all` rather than shown on its own (too thin to trust).
+>
+> The `Actual h/BCP` cell shows the geometric mean with its **typical range** `[low–high]` (≈68%, sample GSD, `k=1`). The range is shown only when `n >= 3`; for `n < 3` the bare point is shown (its `n` is in the `n` column — too few samples for a trustworthy range).
+
+| Category | Segment | n | Actual h/BCP (typical range) | Est. h/BCP | Drift |
+| -------- | ------- | - | ---------------------------- | ---------- | ----- |
 {for each category with bcp_stories}
-| {category} | {h_per_bcp_by_category}h | {h_per_bcp_estimated_by_category}h | {drift:+}% |
+{for each segment in [micro, story] with n >= 3}
+| {category} | {segment} | {n} | {h_per_bcp_by_category}h [{band.low}–{band.high}] | {h_per_bcp_estimated_by_category}h | {drift:+}% |
+{end}
+| {category} | all | {n_all} | {pooled h_per_bcp_by_category}h{if n_all >= 3} [{pooled band.low}–{pooled band.high}]{end} | {pooled h_per_bcp_estimated_by_category}h | {drift:+}% |
 {end}
 
 **Drift trend (estimated vs actual h/BCP):**

--- a/tests/test_anti_goodhart.py
+++ b/tests/test_anti_goodhart.py
@@ -1,0 +1,112 @@
+"""Anti-Goodhart contract test for the v0.5 honest-measurement-engine.
+
+The whole v0.5 north-star shift rests on one mathematical fact: leverage
+(`estimated_hours / actual_hours`) collapses to ~1.0x once the estimate basis
+is calibrated. Therefore a *leverage target* would reward inflating estimates
+(never calibrating) — the textbook Goodhart trap.
+
+This file locks that invariant two ways:
+  1. **Premise lock (markdown invariant):** the leverage formula the workflow
+     tells the agent to use must stay `estimated_hours / actual_hours`, and the
+     dashboard must carry the anti-Goodhart note. If either drifts, these tests
+     break and force a conscious re-examination.
+  2. **Property lock (executable math):** using that exact formula, calibration
+     drives leverage to 1.0 and estimate inflation drives it up. These encode,
+     in runnable form, *why* leverage must never be promoted to a KPI.
+
+There is no Python compute layer in PULSE (the dashboard math is agent
+instructions), so part 2 re-implements the documented formula and asserts its
+properties — a contract, not a test of internal code.
+"""
+from __future__ import annotations
+
+import statistics
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[1]
+TRACK_DONE = REPO_ROOT / "skills/bmad-pulse-track-done/workflow.md"
+DASHBOARD = REPO_ROOT / "skills/bmad-pulse-dashboard/workflow.md"
+
+
+# --- the documented formulas, re-implemented for the property locks ---------
+
+
+def leverage(estimated_hours: float, actual_hours: float) -> float:
+    """The formula PULSE documents at track-done: leverage = est / act."""
+    return estimated_hours / max(0.01, actual_hours)
+
+
+def geometric_mean(ratios: list[float]) -> float:
+    """The v0.5 baseline estimator: geometric mean of h/BCP ratios."""
+    return statistics.geometric_mean(ratios)
+
+
+# --- Part 1: premise locks (markdown invariants) ----------------------------
+
+
+def test_leverage_formula_is_estimated_over_actual():
+    """The premise of the whole invariant: leverage stays est/actual. If this
+    formula changes, the anti-Goodhart reasoning must be re-derived."""
+    text = TRACK_DONE.read_text()
+    assert "leverage_ratio = estimated_hours / actual_hours" in text
+
+
+def test_dashboard_carries_anti_goodhart_note():
+    """The 'why' must live next to the leverage number on the dashboard."""
+    text = DASHBOARD.read_text()
+    assert "Anti-Goodhart invariant" in text
+    assert "leverage is not a target" in text.lower()
+    assert "~1.0x by construction" in text
+    assert "vs PLAN" in text and "never" in text and "vs human" in text
+
+
+def test_predictability_is_named_the_durable_signal():
+    """The note must point to predictability (drift→0), not the multiplier, as
+    the signal that matters."""
+    text = DASHBOARD.read_text().lower()
+    assert "predictability" in text
+    assert "drift" in text and "converg" in text
+
+
+# --- Part 2: property locks (executable math) -------------------------------
+
+
+def test_calibrated_baseline_drives_leverage_to_one():
+    """When the estimate basis is calibrated — i.e. estimated_hours is derived
+    from a baseline (geometric mean of past h/BCP) that matches the realized
+    h/BCP — leverage collapses to ~1.0x. A healthy state is NOT a big number."""
+    bcp_total = 20
+    past_ratios = [3.8, 4.2, 4.0, 4.1, 3.9]  # realized h/BCP history
+    calibrated_baseline = geometric_mean(past_ratios)  # ~4.0
+    estimated_hours = calibrated_baseline * bcp_total
+    actual_hours = geometric_mean(past_ratios) * bcp_total  # reality matches
+    lev = leverage(estimated_hours, actual_hours)
+    assert abs(lev - 1.0) < 1e-9, (
+        f"calibrated baseline must drive leverage to ~1.0, got {lev}"
+    )
+
+
+def test_inflated_estimate_inflates_leverage():
+    """Same actuals, an inflated (uncalibrated) estimate → leverage spikes.
+    This is the Goodhart trap made explicit: a leverage *goal* would reward
+    exactly this inflation, not real speed."""
+    bcp_total = 20
+    actual_hours = 4.0 * bcp_total  # 80h realized
+    calibrated = leverage(4.0 * bcp_total, actual_hours)
+    inflated = leverage(8.0 * bcp_total, actual_hours)  # estimate doubled
+    assert calibrated < inflated, "inflating the estimate must raise leverage"
+    assert abs(inflated - 2.0) < 1e-9, "doubled estimate → 2.0x, pure artifact"
+
+
+def test_leverage_target_would_reward_not_calibrating():
+    """Direct statement of the perverse incentive: across a calibration path
+    where estimates converge on reality, leverage monotonically falls toward
+    1.0 — so maximizing leverage means refusing to calibrate."""
+    actual = 4.0
+    # estimate basis improving from 3x-inflated down to calibrated
+    estimate_bases = [12.0, 8.0, 6.0, 4.8, 4.0]
+    levs = [leverage(e, actual) for e in estimate_bases]
+    assert levs == sorted(levs, reverse=True), (
+        "as calibration improves, leverage must fall — a leverage goal fights it"
+    )
+    assert abs(levs[-1] - 1.0) < 1e-9, "fully calibrated endpoint is 1.0x"

--- a/tests/test_honest_engine.py
+++ b/tests/test_honest_engine.py
@@ -1,0 +1,181 @@
+"""Invariant tests for the v0.5 honest-measurement-engine (h/BCP baseline).
+
+The dashboard h/BCP baseline is computed by the agent following the
+instructions in ``skills/bmad-pulse-dashboard/workflow.md`` — there is no
+Python compute layer to unit-test. These are meta/invariant tests in the same
+spirit as ``test_bcp_integration.py``: they pin the *math the workflow tells
+the agent to use* so a future edit cannot silently regress the geometric mean
+back to an arithmetic mean (which is biased high and outlier-fragile for
+multiplicative ratios).
+
+Phase 1 scope: geometric mean only. Segmentation (Phase 2) and the confidence
+band (Phase 3) get their own invariants when they land.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[1]
+DASHBOARD = REPO_ROOT / "skills/bmad-pulse-dashboard/workflow.md"
+TRACK_DONE = REPO_ROOT / "skills/bmad-pulse-track-done/workflow.md"
+TRACK_BACKFILL = REPO_ROOT / "skills/bmad-pulse-track-backfill/workflow.md"
+
+
+def test_baseline_uses_geometric_mean():
+    """h_per_bcp_by_category must instruct the agent to use the geometric mean,
+    with the formula spelled out so the computation is deterministic."""
+    text = DASHBOARD.read_text()
+    assert "h_per_bcp_by_category" in text
+    assert "geometric mean" in text, (
+        "the per-category h/BCP baseline must use the geometric mean (v0.5)"
+    )
+    assert "exp(mean(ln(" in text, (
+        "the geometric-mean formula must be inlined so the agent computes it "
+        "deterministically"
+    )
+
+
+def test_baseline_is_not_arithmetic_mean():
+    """Regression guard: the pre-0.5 arithmetic phrasing must be gone, so an
+    edit cannot quietly revert to the biased arithmetic mean."""
+    text = DASHBOARD.read_text()
+    assert "the mean of `bcp_recorded.h_per_bcp_actual`" not in text, (
+        "found the pre-0.5 arithmetic-mean phrasing — baseline regressed"
+    )
+
+
+def test_estimated_baseline_is_geometric_too():
+    """The estimated-side baseline must use the same geometric mean so the
+    drift comparison is apples-to-apples."""
+    text = DASHBOARD.read_text()
+    # The estimated line references the same geometric mean over the estimated
+    # ratios; assert both the field and the geometric framing co-occur.
+    assert "h_per_bcp_estimated_by_category" in text
+    assert text.count("geometric mean") >= 2, (
+        "both actual and estimated per-category baselines must be geometric"
+    )
+
+
+def test_outlier_rationale_documented():
+    """The 'why' must live next to the instruction: ratios are multiplicative
+    and the geometric mean resists outliers. Keeps the choice from being
+    'cleaned up' by a future editor who reads it as gratuitous."""
+    text = DASHBOARD.read_text().lower()
+    assert "multiplicative" in text
+    assert "outlier" in text
+
+
+def test_v050_semantics_change_is_flagged():
+    """Dashboard authors must be warned that baselines shift under the new
+    math (arithmetic -> geometric), mirroring the existing 'pre-0.5.0' marker
+    style used elsewhere in the workflow."""
+    text = DASHBOARD.read_text()
+    assert "v0.5.0" in text and "geometric" in text
+    assert "pre-0.5.0" in text, (
+        "the semantics-change note must contrast against pre-0.5.0 behavior"
+    )
+
+
+# --- Phase 2: micro vs story-size segmentation -----------------------------
+
+
+def test_segmentation_splits_by_observed_median():
+    """The micro/story split must be the observed median of bcp_recorded.total,
+    not a fixed threshold (which would assume the BCP scale)."""
+    text = DASHBOARD.read_text()
+    assert "segment_split" in text
+    assert "median" in text and "bcp_recorded.total" in text, (
+        "the split must be the median of the observed BCP totals"
+    )
+    assert "micro" in text and "story" in text
+
+
+def test_split_is_data_driven_no_config_knob():
+    """Zero-coupling guard: no pulse_bcp_micro_threshold config key — a fixed
+    threshold would bake in an assumption about the BCP point scale."""
+    text = DASHBOARD.read_text()
+    assert "pulse_bcp_micro_threshold" not in text, (
+        "segmentation must be data-driven (observed median), not a config knob"
+    )
+
+
+def test_median_guarded_against_empty():
+    """The independence invariant: median is only computed when bcp_stories is
+    non-empty — median([]) must never be evaluated."""
+    text = DASHBOARD.read_text()
+    assert "non-empty" in text and "median([])" in text, (
+        "the workflow must state median is skipped on empty bcp_stories"
+    )
+
+
+def test_thin_segment_falls_back_to_pooled():
+    """A segment with n<3 must fold into the category pooled baseline rather
+    than emit a thin/untrustworthy row."""
+    text = DASHBOARD.read_text()
+    assert "n < 3" in text or "n >= 3" in text
+    assert "pooled" in text.lower() and "fallback" in text.lower()
+
+
+def test_pooled_all_row_still_emitted():
+    """Continuity with pre-0.5 dashboards: an `all` (pooled) row is always
+    rendered per category."""
+    text = DASHBOARD.read_text()
+    assert "| {category} | all |" in text, (
+        "the per-category pooled `all` row must remain for backward continuity"
+    )
+
+
+def test_no_persisted_segment_tag():
+    """Segmentation happens at dashboard read time; the recording workflows
+    must not write a derived `segment` tag into bcp_recorded (which would
+    freeze the split and write a BCP-derived judgment into pulse_metrics)."""
+    for wf in (TRACK_DONE, TRACK_BACKFILL):
+        text = wf.read_text()
+        assert "segment:" not in text, (
+            f"{wf.name} must not persist a derived segment tag on bcp_recorded"
+        )
+
+
+# --- Phase 3: confidence band ----------------------------------------------
+
+
+def test_baseline_carries_confidence_band():
+    """Each baseline must report a typical range (band), not a bare point."""
+    text = DASHBOARD.read_text()
+    assert "h_per_bcp_band" in text
+    assert "[geo_mean / GSD, geo_mean * GSD]" in text, (
+        "the band must be the geometric mean divided/multiplied by the GSD"
+    )
+
+
+def test_band_uses_sample_gsd_n_minus_1():
+    """The geometric standard deviation must be the *sample* GSD (n-1), since
+    we estimate from a sample, not enumerate a population."""
+    text = DASHBOARD.read_text()
+    assert "sample_std(ln(h_per_bcp_actual))" in text
+    assert "n-1" in text and "sample, not population" in text
+
+
+def test_band_is_k1_typical_range_not_95ci():
+    """k=1 (~68%, 'typical range') — explicitly not a 95% CI, which would be
+    too wide to act on at PULSE's small n."""
+    text = DASHBOARD.read_text()
+    assert "k = 1" in text or "`k = 1`" in text
+    assert "typical range" in text.lower()
+    assert "not a 95% CI" in text or "not a 95%" in text
+
+
+def test_no_band_when_n_lt_3():
+    """A band requires n>=3; n<3 shows the bare point with an (n=2)/(n=1)
+    marker — a 2-sample GSD has 1 degree of freedom and is unstable."""
+    text = DASHBOARD.read_text()
+    assert "n >= 3" in text
+    assert "(n=2)" in text and "degree of freedom" in text
+
+
+def test_band_render_shows_range_only_for_segment_rows():
+    """The rendered table must show the [low–high] range for segment rows
+    (n>=3 by construction) and gate the pooled row's range on n_all>=3."""
+    text = DASHBOARD.read_text()
+    assert "[{band.low}–{band.high}]" in text
+    assert "{if n_all >= 3} [{pooled band.low}–{pooled band.high}]{end}" in text


### PR DESCRIPTION
## v0.5 — Engine de medição honesto

Refaz o **h/BCP** por categoria do dashboard pra o número ser honesto, não lisonjeiro. Operacionaliza a virada de métrica-norte do roadmap: de *multiplicador de alavancagem* → **previsibilidade**. Escopo só PULSE — `bmad-bcp-recalibrate` e telemetria de tokens ficam de fora. PULSE segue passivo e zero-coupled ao `bmad-module-bcp` (lê `bcp.*`, nunca escreve baseline).

**Afeta apenas `pulse_estimation_method=bcp`.** Dashboards sem BCP ficam inalterados; projeto sem BCP é no-op (mediana/segmentação só computam dentro do bloco BCP já gated).

### O que mudou (4 fases)

| Fase | Mudança |
|------|---------|
| **1 — Média geométrica** | Baseline h/BCP por categoria vira média geométrica dos ratios por story (`exp(mean(ln(ratio)))`), não aritmética. Tendência central não-enviesada e resistente a outlier pra um ratio multiplicativo. |
| **2 — Segmentação** | Split micro vs story-size pela **mediana observada** do total BCP. Data-driven (sem config key, sem assumir a escala BCP — preserva o zero-coupling); linha `all` pooled pra continuidade; segmentos finos (n<3) dobram no pooled. Read-time, nada persistido. |
| **3 — Faixa de confiança** | Cada baseline mostra faixa típica `[low–high]` (GSD amostral, `k=1`, ~68%) + tamanho de amostra `n`; banda só emitida em `n>=3`. |
| **4 — Anti-Goodhart** | Contract test + nota no dashboard: base de estimativa calibrada empurra a alavancagem (`estimated/actual`) pra ~1.0x por construção, então alavancagem **não** é meta — previsibilidade (drift de h/BCP → 0) é o sinal durável. A inversão da métrica-herói em si é v0.6; isto só trava o invariante. |

### Decisões de design (resolvidas no planejamento)

- **Split por mediana, não threshold fixo** — um "N BCP = micro" hard-coded assumiria a escala BCP e quebraria o zero-coupling PULSE↔BCP. A mediana auto-calibra por projeto.
- **k=1 / GSD amostral (n-1) / n≥3** — no n pequeno do PULSE, uma banda 95% seria inacionável e um GSD de 2 amostras (1 grau de liberdade) é instável.
- **Segmentação read-time, nada persistido** — mantém a mediana auto-calibrante e evita gravar um julgamento derivado de BCP no `pulse_metrics`.

### Testes

22 testes novos (invariantes + contrato) em `tests/test_honest_engine.py` e `tests/test_anti_goodhart.py`. A matemática do dashboard é instrução pro agente (sem camada Python de cálculo), então os testes da engine fixam *a matemática que o workflow manda o agente usar*; o arquivo anti-Goodhart adiciona travas de propriedade executáveis (calibração → 1.0x; inflação → alavancagem sobe). **Suíte completa: 153 verde** (golden parity + cross-file invariants intactos).

### Release

`feat(dashboard)!` com footer `BREAKING CHANGE:` → release-please bumpa **0.4.x → 0.5.0** (breaking pré-1.0 = minor via `bump-minor-pre-major`). A superfície breaking é **só parsers do markdown do dashboard** (novas colunas `Segment`/`n`, faixa `[low–high]`); o dashboard legível e as seções sem BCP ficam inalterados. Notas de migração em `docs/MIGRATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
