### PR TITLE
feat(dashboard)!: v0.6 inverter o velocímetro (previsibilidade como métrica-herói, regime, celebração por acurácia)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,27 @@ python3 .claude/skills/bmad-pulse-setup/scripts/reconcile-skills.py \
 
 ---
 
+## v0.5.0 → v0.6.0 — Inverter o velocímetro (previsibilidade como herói)
+
+**Quem isto afeta:** todos os usuários do dashboard e do track-done; mais profundamente quem usa `pulse_estimation_method=bcp`. Nada na coleta de dados muda — a virada é em como os números são **enquadrados**.
+
+A v0.6 age sobre a engine honesta da v0.5: troca a métrica-herói de **alavancagem** → **previsibilidade/acurácia**. Um `~1.0x` estável é saudável; um multiplicador alto sinaliza estimativa inflada, não velocidade. PULSE segue passivo e zero-**write**-coupled ao `bmad-module-bcp`.
+
+### O que muda
+
+- **Métrica-herói invertida.** O `General Statistics` do dashboard agora **lidera** com `Predictability` (mediana do erro de estimativa por story `|actual−estimated|/estimated`, menor = melhor, com seta de tendência) e demove `Avg AI Leverage` pra uma linha de contexto `AI Leverage (vs PLAN) — context, not a target`.
+- **Sinal de convergência.** Nova seção "Baseline convergence" mostra se o `h/BCP` está estabilizando (mediana de `|drift|` da 1ª vs 2ª metade + banda estreitando). Precisa de ≥4 stories BCP.
+- **Detecção de regime.** PULSE passa a **ler** `estimated_hours_basis` (read-only) pra rotular cada multiplicador pela base (`vs PLAN (bcp)`, `vs PLAN (hours)`, …), com fallback pro `pulse_estimation_method`. Nunca escreve o campo, nunca deriva horas dele.
+- **Celebração invertida.** O `track-done` (e `track-backfill`) param de premiar leverage alto (`🔥 Exceptional!` aposentado). O gatilho agora é **acurácia**: `🎯 On-plan` quando a estimativa erra ≤15%; `⚠ Off-plan — review the estimate basis` quando erra ≥50%. Os `pulse_leverage_threshold_*` ficam no `module.yaml` por back-compat, mas não disparam mais celebração.
+
+### O que você precisa fazer
+
+**Nada no disco** além do upgrade normal (`/bmad-pulse-setup`). A mudança é nos workflows; o próximo `/bmad-pulse-dashboard` e `/bmad-pulse-track-done` já renderizam o novo enquadramento. Sem migração de dados.
+
+> ⚠ **Breaking para parsers e para quem dependia do troféu de leverage.** O `General Statistics` foi reordenado, colunas de leverage ganharam "(vs PLAN)" e a celebração do track-done mudou de gatilho. Se você scrapeia o dashboard ou automatiza em cima do "🔥 Exceptional", atualize. O número de leverage continua visível, só sem troféu.
+
+---
+
 ## v0.4.x → v0.5.0 — Honest measurement engine (BCP dashboard)
 
 **Who this affects:** only projects using `pulse_estimation_method=bcp`. If you

--- a/docs/integration/bcp.md
+++ b/docs/integration/bcp.md
@@ -20,7 +20,7 @@ BCP → PULSE coupling: **zero**. BCP optionally reads `pulse_metrics` in its ow
 | --------------------------- | ------------------------------------------------------------ |
 | `estimated_hours` (story)   | BMAD/Amelia originally; BCP overwrites if installed (install = consent) |
 | `estimated_hours_pre_bcp`   | BCP (audit — PULSE ignores)                                   |
-| `estimated_hours_basis`     | BCP (audit — PULSE ignores)                                   |
+| `estimated_hours_basis`     | BCP writes it (audit); since v0.6 PULSE **reads it read-only** to label the dashboard regime — never writes it, never derives hours from it |
 | `bcp.*` (story frontmatter) | BCP exclusively — PULSE reads, never writes                   |
 | `bcp-baseline.yaml`         | BCP exclusively — PULSE never reads or writes                 |
 | `pulse_metrics.*`           | PULSE exclusively                                             |
@@ -37,7 +37,7 @@ does *not* mean PULSE converts BCP points to hours.
 story_id: "5.7"
 estimated_hours: 86.7              # PULSE reads this — writer-agnostic
 estimated_hours_pre_bcp: 80        # BCP audit — PULSE ignores
-estimated_hours_basis: bcp         # BCP audit — PULSE ignores
+estimated_hours_basis: bcp         # BCP audit; PULSE reads read-only for the regime label (never writes/derives)
 category: backend
 
 bcp:                               # written by BCP — PULSE surfaces it

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -78,6 +78,8 @@ Load the `pulse` section from `{main_config}` and resolve all module variables:
 3. Group by epic — infer epic_id from the numeric prefix of story_id (e.g. `15.3` → epic 15, `4.4.1` → epic 4)
 4. Calculate aggregations:
    - Total stories measured
+   - **`predictability_score`** — the v0.6 **hero metric**. The **median** of the per-story estimate error `|actual_hours - estimated_hours| / estimated_hours` across all stories with `pulse_metrics` (floor `estimated_hours` at 0.01 to avoid divide-by-zero). Report as a percentage; **lower is better** — it reads "estimates are X% off, median". Method-agnostic: for BCP stories it equals `|bcp_recorded.drift_pct|` (the BCP totals cancel), so it works whether or not the project uses BCP. Compute it global and per category. Median (not mean) for the same reason the v0.5 baseline is geometric — resist outliers. Pair it with a **trend arrow**: split the stories in story-order (chronological proxy) into first half vs second half and compare each half's median error → `↓ converging` / `→ stable` / `↑ diverging`. Needs `>= 4` stories for a trend; fewer → no arrow.
+   - **`estimate_regime`** (v0.6 regime detection) — the basis each `estimated_hours` was derived from, read **read-only** from the story's `estimated_hours_basis` frontmatter field when present (`bcp` / `hours` / `story_points` / `tshirt`), falling back to `{pulse_estimation_method}` when the field is absent. PULSE **never writes** `estimated_hours_basis` and **never derives hours from it** — it only labels what each multiplier is measured *against* (so "5x" reads "vs PLAN (bcp)" not an unqualified number). Report the dominant regime across stories for the leverage context line; annotate a story in the breakdown when its regime differs from the project default. (`estimated_hours_pre_bcp` stays ignored.)
    - Average, minimum, and maximum leverage
    - Total estimated hours vs total actual hours
    - First-pass rate
@@ -103,6 +105,7 @@ Load the `pulse` section from `{main_config}` and resolve all module variables:
      - `h_per_bcp_estimated_by_category` — same **geometric mean**, segmented the same way (per `(category, segment)` plus pooled `all`), over `bcp_recorded.h_per_bcp_estimated` (for the drift comparison).
      - `h_per_bcp_band` — for each baseline (every `(category, segment)` and each pooled `all`), a **confidence band** around the geometric mean of `bcp_recorded.h_per_bcp_actual`, so the baseline reads as a range, not false precision. Compute the **sample geometric standard deviation** `GSD = exp(sample_std(ln(h_per_bcp_actual)))`, where `sample_std` uses the `n-1` (sample, not population) denominator — we estimate, not enumerate. The band is `[geo_mean / GSD, geo_mean * GSD]` (multiplier `k = 1`, ≈ 68% of a log-normal sample — a **typical range**, not a 95% CI; with PULSE's small `n` a wider band would be unactionable). **Require `n >= 3` to emit a band**; for `n < 3` emit the point with an explicit `(n=2)` / `(n=1)` marker and no interval (a GSD from 2 samples has 1 degree of freedom — one outlier distorts it). Carry `n` alongside every baseline so thin samples are visible. (Since v0.5.0.)
      - `drift_trend` — ordered list of `(story_id, bcp_recorded.drift_pct)` for `bcp_stories` (story-order = chronological proxy)
+     - `h_per_bcp_convergence` — the v0.6 **self-referential drift signal**: is the h/BCP baseline *stabilizing* over time? Split `drift_trend` in story-order into a first half and a second half and compare the **median `|drift_pct|`** of each: second-half median meaningfully **lower** → `converging` (estimates closing on reality); meaningfully **higher** → `diverging`; within a small tolerance → `stable`. The confidence band (`h_per_bcp_band`) narrowing across the same split is corroborating evidence (report it alongside). **Requires `>= 4` `bcp_stories`** for a reading — fewer → `insufficient data (thin sample)`, no label. This consumes the v0.5 drift/band data; it does not recompute raw ratios.
      - `top_bcp_stories` — `bcp_stories` sorted by `bcp_recorded.total` desc, top 5 (proxy for "elements driving BCP" — PULSE does not read `bcp.breakdown`, so it ranks by total points per story)
 
 ### Step 2: Generate Dashboard
@@ -121,16 +124,19 @@ For `markdown` format (default), write `{dashboard_file}` with the following str
 
 ## 🏆 General Statistics
 
-| Metric                  | Value              |
-| ----------------------- | ------------------ |
-| Stories measured        | {total}            |
-| Avg AI Leverage         | {avg}x             |
-| Human estimated hours   | {total_estimated}h |
-| Actual AI hours         | {total_actual}h    |
-| Hours saved             | {saved}h           |
-| First-pass rate         | {rate}%            |
+| Metric                  | Value                                |
+| ----------------------- | ------------------------------------ |
+| Stories measured        | {total}                              |
+| **Predictability**      | **{predictability_score}% off (median) {trend_arrow}** |
+| Human estimated hours   | {total_estimated}h                   |
+| Actual AI hours         | {total_actual}h                      |
+| Hours saved             | {saved}h                             |
+| First-pass rate         | {rate}%                              |
+| AI Leverage (vs PLAN, {dominant_regime}) | {avg}x — context, not a target |
 
-> **Anti-Goodhart invariant — leverage is not a target.** `leverage = estimated_hours / actual_hours`. Once the estimate basis is calibrated (estimates derived from a baseline that matches reality), this ratio collapses to **~1.0x by construction** — so a *high* multiplier signals an inflated or uncalibrated estimate basis, **not** velocity, and a *leverage goal* would literally reward never calibrating. The durable signal is **predictability**: the per-category h/BCP drift converging on zero (do estimates match outcomes?). Read every multiplier as "vs PLAN", never "vs human". (The hero-metric inversion lands in v0.6; v0.5 only locks this invariant.)
+> **Predictability is the hero number** (lower = estimates closer to reality; `↓` = converging). Leverage is shown as context only and read "vs PLAN ({dominant_regime})", never "vs human" — the regime is the estimate basis (`estimated_hours_basis`, read-only) so the multiplier is read against the right plan. A high multiplier signals an uncalibrated estimate basis, not speed (see the anti-Goodhart invariant below).
+
+> **Anti-Goodhart invariant — leverage is not a target.** `leverage = estimated_hours / actual_hours`. Once the estimate basis is calibrated (estimates derived from a baseline that matches reality), this ratio collapses to **~1.0x by construction** — so a *high* multiplier signals an inflated or uncalibrated estimate basis, **not** velocity, and a *leverage goal* would literally reward never calibrating. The durable signal is **predictability**: the per-category h/BCP drift converging on zero (do estimates match outcomes?). Read every multiplier as "vs PLAN", never "vs human". (v0.5 locked this invariant; v0.6 acted on it — predictability now leads the dashboard and the track-done celebration triggers on accuracy, not leverage magnitude.)
 
 <!-- CONDITIONAL: include only if pulse_include_trend_chart == yes -->
 ## 📈 Leverage Trend by Epic
@@ -146,8 +152,8 @@ Example: Epic 14: ████████░░ 3.5x (4 stories)
 
 ## 📊 Leverage by Category
 
-| Category | Avg Leverage | Stories | Best |
-| -------- | ------------ | ------- | ---- |
+| Category | Avg Leverage (vs PLAN) | Stories | Best |
+| -------- | ---------------------- | ------- | ---- |
 {for each category in pulse_dev_categories}
 | {category} | {x}x | {n} | {best} |
 {end}
@@ -221,6 +227,10 @@ Epic {N}: {bcp} BCP ({count} stories)
 | {category} | all | {n_all} | {pooled h_per_bcp_by_category}h{if n_all >= 3} [{pooled band.low}–{pooled band.high}]{end} | {pooled h_per_bcp_estimated_by_category}h | {drift:+}% |
 {end}
 
+**Baseline convergence (is h/BCP stabilizing?):**
+
+> {if bcp_stories count >= 4}**{h_per_bcp_convergence}** — median |drift| moved from {first_half_median}% (first half) to {second_half_median}% (second half); the confidence band {band narrowed / widened / held} over the same split. Converging is the healthy direction: estimates closing on reality.{else}_Insufficient data (thin sample — need ≥4 BCP stories for a convergence reading)._{end}
+
 **Drift trend (estimated vs actual h/BCP):**
 
 {for each (story_id, drift_pct) in drift_trend}
@@ -246,8 +256,8 @@ Epic {N}: {bcp} BCP ({count} stories)
 
 ## 📋 Story Breakdown
 
-| Story | Est. | Actual | Leverage | Quality | Category |
-| ----- | ---- | ------ | -------- | ------- | -------- |
+| Story | Est. | Actual | Leverage (vs PLAN) | Quality | Category |
+| ----- | ---- | ------ | ------------------ | ------- | -------- |
 
 {for each story with pulse_metrics data}
 | {id} | {est}h | {actual}h | {lev}x | {quality} | {cat} |

--- a/skills/bmad-pulse-track-backfill/workflow.md
+++ b/skills/bmad-pulse-track-backfill/workflow.md
@@ -141,6 +141,7 @@ Leverage:
 elapsed_minutes = (HF - HI) in minutes
 actual_hours    = effective_hours ?? max(0.01, elapsed_minutes / 60)
 leverage_ratio  = estimated_hours / actual_hours
+estimate_error_pct = round(abs(actual_hours - estimated_hours) / max(0.01, estimated_hours) * 100, 1)  # |drift_pct| for BCP stories
 first_pass      = review_cycles == 1
 ```
 
@@ -220,11 +221,12 @@ Display (respect `pulse_levi_verbosity`):
    HI: {start_ts}  →  HF: {end_ts}
    Human estimate: {estimated_hours}h ({dev_count} devs)
    Actual AI time: {actual_hours}h ({elapsed_minutes}min wall-clock)
-   AI Leverage: {leverage_ratio}x
+   AI Leverage: {leverage_ratio}x (vs PLAN, not vs human)
+   Estimate accuracy: {estimate_error_pct}% off plan
    {if bcp_recorded}BCP: {bcp_recorded.total} pts | {bcp_recorded.h_per_bcp_actual}h/BCP actual vs {bcp_recorded.h_per_bcp_estimated}h/BCP est ({bcp_recorded.drift_pct:+}% drift){end}
    Quality: {first_pass ? "✅ first-pass" : "🔄 " + review_cycles + " cycles"}
    Category: {category}
-   {leverage_ratio >= pulse_leverage_threshold_exceptional ? "🔥 Exceptional!" : leverage_ratio >= pulse_leverage_threshold_solid ? "💪 Solid!" : leverage_ratio < pulse_leverage_warning_threshold ? "⚠ Below expectations — review estimates." : "📊 Data recorded."}
+   {estimate_error_pct <= 15 ? (first_pass ? "🎯 On-plan! (estimate within 15%, first-pass)" : "🎯 On-plan (estimate within 15%)") : estimate_error_pct >= 50 ? "⚠ Off-plan — review the estimate basis, not the speed." : "📊 Data recorded."}
 
    💡 {if pulse_levi_coaching_mode == yes}Run /bmad-pulse-track-start and /bmad-pulse-track-done on future stories to capture process health and halts, which backfill cannot reconstruct.{end}
 ```

--- a/skills/bmad-pulse-track-done/workflow.md
+++ b/skills/bmad-pulse-track-done/workflow.md
@@ -60,9 +60,9 @@ Load the config from the `pulse` section of `{main_config}` and resolve all modu
 - `pulse_sprint_status_filename`
 - `pulse_estimation_method` (story_points / hours / t-shirt / bcp)
 - `pulse_story_point_hours_factor` (story points → hours conversion factor)
-- `pulse_leverage_threshold_exceptional` (e.g. 4)
-- `pulse_leverage_threshold_solid` (e.g. 2)
-- `pulse_leverage_warning_threshold` (e.g. 1)
+- `pulse_leverage_threshold_exceptional` (e.g. 4) — _legacy since v0.6: no longer drives celebration (kept for back-compat)_
+- `pulse_leverage_threshold_solid` (e.g. 2) — _legacy since v0.6: no longer drives celebration_
+- `pulse_leverage_warning_threshold` (e.g. 1) — _legacy since v0.6: no longer drives celebration_
 - `pulse_alert_on_halt` (yes / warn / no)
 - `pulse_alert_unused_skills` (yes / no)
 - `pulse_process_health_checks` (standard / strict / minimal)
@@ -163,6 +163,7 @@ halt_minutes = sum(
 
 actual_hours = effective_hours ?? max(0.01, (elapsed_minutes - halt_minutes) / 60)
 leverage_ratio = estimated_hours / actual_hours
+estimate_error_pct = round(abs(actual_hours - estimated_hours) / max(0.01, estimated_hours) * 100, 1)  # how far the estimate was from reality; equals |drift_pct| for BCP stories
 first_pass = review_cycles == 1
 ```
 
@@ -225,12 +226,14 @@ Display in the terminal:
    📊 Efficiency
    Human estimate: {estimated_hours}h ({dev_count} devs)
    Actual AI time: {actual_hours}h ({elapsed_minutes}min wall-clock)
-   AI Leverage: {leverage_ratio}x
+   AI Leverage: {leverage_ratio}x (vs PLAN, not vs human)
+   Estimate accuracy: {estimate_error_pct}% off plan
    {if bcp_recorded}BCP: {bcp_recorded.total} pts | {bcp_recorded.h_per_bcp_actual}h/BCP actual vs {bcp_recorded.h_per_bcp_estimated}h/BCP est ({bcp_recorded.drift_pct:+}% drift){end}
    Quality: {first_pass ? "✅ first-pass" : "🔄 " + review_cycles + " cycles"}
    Tasks: {task_count}
    Category: {category}
-   {leverage_ratio >= pulse_leverage_threshold_exceptional ? "🔥 Exceptional!" : leverage_ratio >= pulse_leverage_threshold_solid ? "💪 Solid!" : leverage_ratio < pulse_leverage_warning_threshold ? "⚠ Below expectations — review estimates or process." : "📊 Data recorded."}
+   {estimate_error_pct <= 15 ? (first_pass ? "🎯 On-plan! (estimate within 15%, first-pass)" : "🎯 On-plan (estimate within 15%)") : estimate_error_pct >= 50 ? "⚠ Off-plan — review the estimate basis, not the speed." : "📊 Data recorded."}
+   <!-- v0.6: celebration triggers on estimate ACCURACY (on-plan), not on leverage magnitude. A high multiplier is an uncalibrated estimate, not a win (anti-Goodhart). pulse_leverage_threshold_exceptional/solid are retired as celebration triggers — leverage is reported "vs PLAN" as context only. -->
 
    📋 Process Health
    Flow: {flow_check}

--- a/tests/test_invert_speedometer.py
+++ b/tests/test_invert_speedometer.py
@@ -1,0 +1,204 @@
+"""Invariant tests for the v0.6 'invert the speedometer' milestone.
+
+v0.6 makes predictability/accuracy the hero metric and demotes leverage to
+context. The dashboard math is agent instructions (no Python compute layer),
+so these pin the *math and ordering the workflow tells the agent to use* — a
+future edit cannot silently re-promote leverage to the headline.
+
+Phase 1 scope: hero metric only (median estimate-error + trend, leverage
+demoted). Convergence signal (Phase 2), regime detection (Phase 3) and the
+celebration inversion (Phase 4) get their own invariants when they land.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[1]
+DASHBOARD = REPO_ROOT / "skills/bmad-pulse-dashboard/workflow.md"
+TRACK_DONE = REPO_ROOT / "skills/bmad-pulse-track-done/workflow.md"
+TRACK_BACKFILL = REPO_ROOT / "skills/bmad-pulse-track-backfill/workflow.md"
+BCP_DOC = REPO_ROOT / "docs/integration/bcp.md"
+
+
+def test_predictability_score_is_defined_as_hero():
+    """The aggregation must define predictability_score and call it the hero."""
+    text = DASHBOARD.read_text()
+    assert "predictability_score" in text
+    assert "hero metric" in text.lower()
+
+
+def test_predictability_is_median_estimate_error():
+    """Hero = median of per-story |actual - estimated| / estimated; median (not
+    mean) to resist outliers, consistent with the v0.5 geometric choice."""
+    text = DASHBOARD.read_text()
+    assert "|actual_hours - estimated_hours| / estimated_hours" in text
+    assert "median" in text.lower()
+    assert "lower is better" in text.lower()
+
+
+def test_predictability_is_method_agnostic():
+    """Works with or without BCP: for BCP stories it equals |drift_pct|."""
+    text = DASHBOARD.read_text()
+    assert "method-agnostic" in text.lower()
+    assert "|bcp_recorded.drift_pct|" in text
+
+
+def test_predictability_has_trend_arrow():
+    """The hero carries a convergence trend (first half vs second half)."""
+    text = DASHBOARD.read_text()
+    assert "trend_arrow" in text
+    assert "converging" in text and "diverging" in text
+
+
+def test_predictability_leads_table_before_leverage():
+    """Ordering invariant: in General Statistics the Predictability row must
+    appear BEFORE the leverage row — leverage is no longer the headline."""
+    text = DASHBOARD.read_text()
+    pred_idx = text.find("| **Predictability**")
+    lev_idx = text.find("| AI Leverage (vs PLAN")
+    assert pred_idx != -1 and lev_idx != -1, "both rows must be present"
+    assert pred_idx < lev_idx, "Predictability must lead; leverage comes after"
+
+
+def test_leverage_demoted_to_context():
+    """Leverage must be labelled vs PLAN and explicitly marked as context, not
+    a target — and the old 'Avg AI Leverage' headline row must be gone."""
+    text = DASHBOARD.read_text()
+    assert "AI Leverage (vs PLAN" in text
+    assert "context, not a target" in text
+    assert "| Avg AI Leverage         | {avg}x             |" not in text, (
+        "the pre-v0.6 leverage headline row must be replaced"
+    )
+
+
+# --- Phase 2: self-referential h/BCP convergence ----------------------------
+
+
+def test_convergence_signal_is_defined():
+    """h_per_bcp_convergence must be a defined self-referential drift signal."""
+    text = DASHBOARD.read_text()
+    assert "h_per_bcp_convergence" in text
+    assert "self-referential" in text.lower()
+    assert "stabiliz" in text.lower()
+
+
+def test_convergence_uses_half_split_of_drift_trend():
+    """The reading compares median |drift| of the first vs second half of
+    drift_trend — falling = converging, rising = diverging."""
+    text = DASHBOARD.read_text()
+    assert "first half" in text and "second half" in text
+    assert "converging" in text and "diverging" in text and "stable" in text
+
+
+def test_convergence_corroborated_by_band():
+    """The v0.5 confidence band narrowing is reported as corroborating evidence
+    — Phase 2 consumes v0.5 data, it does not recompute raw ratios."""
+    text = DASHBOARD.read_text()
+    assert "h_per_bcp_band" in text and "narrow" in text.lower()
+    assert "does not recompute raw ratios" in text
+
+
+def test_convergence_needs_min_4_stories():
+    """A trend needs >=4 BCP stories; fewer is an explicit thin-sample no-read,
+    not a fabricated label."""
+    text = DASHBOARD.read_text()
+    assert ">= 4" in text or "≥4" in text
+    assert "insufficient data" in text.lower() or "thin sample" in text.lower()
+
+
+# --- Phase 3: regime detection via estimated_hours_basis --------------------
+
+
+def test_regime_read_from_estimated_hours_basis():
+    """The regime label is read read-only from the story's
+    estimated_hours_basis frontmatter field."""
+    text = DASHBOARD.read_text()
+    assert "estimate_regime" in text
+    assert "estimated_hours_basis" in text
+    assert "read-only" in text.lower() or "read **read-only**" in text
+
+
+def test_regime_falls_back_to_global_method():
+    """When estimated_hours_basis is absent, regime falls back to the global
+    pulse_estimation_method."""
+    text = DASHBOARD.read_text()
+    assert "pulse_estimation_method" in text
+    assert "fall" in text.lower() and "absent" in text.lower()
+
+
+def test_regime_labels_leverage_vs_plan_regime():
+    """The leverage context line must carry the regime: 'vs PLAN ({regime})'."""
+    text = DASHBOARD.read_text()
+    assert "vs PLAN, {dominant_regime}" in text or "vs PLAN ({dominant_regime})" in text
+
+
+def test_regime_read_is_zero_write_coupled():
+    """v0.6 starts READING estimated_hours_basis but the zero-WRITE-coupling
+    invariant holds: PULSE never writes it (recording workflows don't mention
+    it) and never derives hours from it."""
+    for wf in (TRACK_DONE, TRACK_BACKFILL):
+        assert "estimated_hours_basis" not in wf.read_text(), (
+            f"{wf.name} must never write estimated_hours_basis"
+        )
+    assert "never derives hours from it" in DASHBOARD.read_text()
+
+
+def test_integration_doc_flips_basis_to_read_only():
+    """docs/integration/bcp.md must reflect the reversal: estimated_hours_basis
+    is now read read-only (not 'ignores'), while estimated_hours_pre_bcp stays
+    ignored and zero-coupling language remains."""
+    text = BCP_DOC.read_text()
+    assert "reads it read-only" in text
+    assert "| `estimated_hours_basis`     | BCP (audit — PULSE ignores)" not in text, (
+        "the old 'PULSE ignores' row for estimated_hours_basis must be gone"
+    )
+    assert "estimated_hours_pre_bcp`   | BCP (audit — PULSE ignores)" in text, (
+        "estimated_hours_pre_bcp must remain ignored"
+    )
+    assert "zero-coupled" in text or "zero coupling" in text
+
+
+# --- Phase 4: vs-PLAN labels + inverted celebration -------------------------
+
+
+def test_estimate_error_pct_computed_in_both_recorders():
+    """track-done and track-backfill must compute the per-story estimate error
+    (|actual - estimated| / estimated) that drives the inverted celebration."""
+    for wf in (TRACK_DONE, TRACK_BACKFILL):
+        text = wf.read_text()
+        assert "estimate_error_pct = round(abs(actual_hours - estimated_hours)" in text
+
+
+def test_celebration_triggers_on_accuracy_not_leverage():
+    """The track-done celebration must trigger on estimate accuracy (on-plan),
+    and the old leverage-magnitude trophy must be gone."""
+    text = TRACK_DONE.read_text()
+    assert "🎯 On-plan" in text
+    assert "estimate_error_pct <= 15 ?" in text
+    assert "🔥 Exceptional!" not in text, "the leverage-magnitude trophy must be retired"
+    assert "leverage_ratio >= pulse_leverage_threshold_exceptional ?" not in text, (
+        "leverage thresholds must no longer drive the celebration"
+    )
+
+
+def test_backfill_celebration_inverted_too():
+    """The backfill card must invert the same way for consistency."""
+    text = TRACK_BACKFILL.read_text()
+    assert "🎯 On-plan" in text and "estimate_error_pct <= 15 ?" in text
+    assert "🔥 Exceptional!" not in text
+
+
+def test_leverage_thresholds_marked_legacy():
+    """The leverage thresholds stay for back-compat but are flagged legacy —
+    they no longer drive any celebration."""
+    text = TRACK_DONE.read_text()
+    assert "legacy since v0.6" in text
+
+
+def test_leverage_labeled_vs_plan_in_cards_and_tables():
+    """Every leverage display reads 'vs PLAN', never 'vs human' as a target."""
+    done = TRACK_DONE.read_text()
+    assert "AI Leverage: {leverage_ratio}x (vs PLAN" in done
+    dash = DASHBOARD.read_text()
+    assert "Avg Leverage (vs PLAN)" in dash
+    assert "Leverage (vs PLAN) | Quality" in dash


### PR DESCRIPTION
## v0.6 — Inverter o velocímetro

Age sobre a engine honesta da v0.5: troca a métrica-herói do dashboard de **alavancagem** → **previsibilidade/acurácia**. Um `~1.0x` estável é saudável; um multiplicador alto sinaliza estimativa inflada, não velocidade. Escopo só PULSE; PULSE segue passivo e zero-**write**-coupled ao `bmad-module-bcp`.

### O que mudou (4 fases)

| Fase | Mudança |
|------|---------|
| **1 — Métrica-herói** | `General Statistics` lidera com `Predictability` (mediana do erro de estimativa por story `\|actual−estimated\|/estimated`, menor=melhor, com seta de tendência). Universal — pra stories BCP equivale a `\|drift_pct\|`. `Avg AI Leverage` demovido pra contexto "vs PLAN, not a target". |
| **2 — Convergência** | Sinal auto-referente: o `h/BCP` está estabilizando? Mediana de `\|drift\|` da 1ª vs 2ª metade + banda estreitando; n≥4 ou "thin sample". |
| **3 — Regime** | PULSE passa a **ler** `estimated_hours_basis` (read-only) pra rotular o multiplicador pela base (`vs PLAN (bcp)` etc.), fallback pro `pulse_estimation_method`. Nunca escreve, nunca deriva horas dele. |
| **4 — Celebração + labels** | `track-done`/`track-backfill` param de premiar leverage alto (`🔥 Exceptional` aposentado); gatilho agora é **acurácia** (`🎯 On-plan` se erro ≤15%, `⚠ Off-plan` se ≥50%). Toda exibição de multiplicador rotulada "vs PLAN". |

### Decisões de design (resolvidas no plano)

- **Métrica-herói = mediana de `|drift|`** (não MAPE nem %-na-banda) — robusta a outlier, coerente com a escolha geométrica da v0.5.
- **Ler `estimated_hours_basis` read-only** — reverte o "ignores" da integração (doc atualizado) mas mantém o zero-**write**-coupling, travado por contract test (`test_regime_read_is_zero_write_coupled`).
- **Threshold de acurácia inline (15%/50%)** — evita arrastar config/help-CSV; os `pulse_leverage_threshold_*` ficam por back-compat, só não disparam celebração.

### Testes

20 testes novos em `tests/test_invert_speedometer.py` (invariantes sobre o markdown dos workflows; sem camada Python de cálculo). 2 testes da Fase 1 atualizados pelo rótulo de regime da Fase 3. **Suíte completa: 173 verde** (golden parity + v0.5 + `test_bcp_integration` intactos).

### Release

`feat(dashboard)!` com `BREAKING CHANGE:` → release-please bumpa **0.5.x → 0.6.0** (breaking pré-1.0 = minor via `bump-minor-pre-major`). Breaking = reordenação do `General Statistics`, colunas de leverage "(vs PLAN)" e celebração por acurácia. Notas em `docs/MIGRATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
