### PR TITLE
feat(track-start): v0.7 a ação que importa (alerta de drift na estimativa + watch-list)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,25 @@ python3 .claude/skills/bmad-pulse-setup/scripts/reconcile-skills.py \
 
 ---
 
+## v0.6.0 → v0.7.0 — A ação que importa (alerta de drift na estimativa)
+
+**Quem isto afeta:** quem usa `/bmad-pulse-track-start` e o dashboard. **Aditivo** — nada existente muda de formato; a v0.7 só **acrescenta** um aviso e uma seção.
+
+A v0.5/v0.6 são retrospectivas (você vê o drift depois que a story fechou). A v0.7 leva o sinal pro **momento do compromisso**: ao iniciar uma story, PULSE avisa se a coorte dela vem errando a estimativa — _antes_ de virar promessa. PULSE segue passivo: o alerta **informa, nunca dirige**.
+
+### O que muda (tudo aditivo)
+
+- **Alerta no track-start.** Ao registrar o start, PULSE computa o drift recente da coorte da story (`category` + segmento de tamanho quando há BCP) e, se as últimas 5 erraram > 25% na mediana (mínimo 3 stories), mostra uma linha **não-bloqueante**: `⚠ Heads up: stories like backend/story were off +N% (median) over the last 5 — re-estimate before committing?`. O start é registrado normalmente; **PULSE nunca altera `estimated_hours`** — reestimar é decisão sua.
+- **Watch-list no dashboard.** Nova seção `🚦 Estimation drift watch` lista as coortes que estão estimando mal agora (mediana > 25%, ≥3 stories), ordenadas por drift, com tendência. Coortes saudáveis são omitidas; tudo saudável → "No cohorts drifting — estimates are tracking".
+
+### O que você precisa fazer
+
+**Nada.** Aditivo, sem migração de dados. Próximo `/bmad-pulse-track-start` e `/bmad-pulse-dashboard` já trazem o aviso e a seção. Os thresholds (`K=5`, `T=25%`) são inline nesta versão.
+
+> ℹ️ **Não-breaking.** Nenhum formato existente foi reordenado ou removido; só houve acréscimos. O alerta é advisory e nunca toca a sua estimativa.
+
+---
+
 ## v0.5.0 → v0.6.0 — Inverter o velocímetro (previsibilidade como herói)
 
 **Quem isto afeta:** todos os usuários do dashboard e do track-done; mais profundamente quem usa `pulse_estimation_method=bcp`. Nada na coleta de dados muda — a virada é em como os números são **enquadrados**.

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -80,6 +80,8 @@ Load the `pulse` section from `{main_config}` and resolve all module variables:
    - Total stories measured
    - **`predictability_score`** — the v0.6 **hero metric**. The **median** of the per-story estimate error `|actual_hours - estimated_hours| / estimated_hours` across all stories with `pulse_metrics` (floor `estimated_hours` at 0.01 to avoid divide-by-zero). Report as a percentage; **lower is better** — it reads "estimates are X% off, median". Method-agnostic: for BCP stories it equals `|bcp_recorded.drift_pct|` (the BCP totals cancel), so it works whether or not the project uses BCP. Compute it global and per category. Median (not mean) for the same reason the v0.5 baseline is geometric — resist outliers. Pair it with a **trend arrow**: split the stories in story-order (chronological proxy) into first half vs second half and compare each half's median error → `↓ converging` / `→ stable` / `↑ diverging`. Needs `>= 4` stories for a trend; fewer → no arrow.
    - **`estimate_regime`** (v0.6 regime detection) — the basis each `estimated_hours` was derived from, read **read-only** from the story's `estimated_hours_basis` frontmatter field when present (`bcp` / `hours` / `story_points` / `tshirt`), falling back to `{pulse_estimation_method}` when the field is absent. PULSE **never writes** `estimated_hours_basis` and **never derives hours from it** — it only labels what each multiplier is measured *against* (so "5x" reads "vs PLAN (bcp)" not an unqualified number). Report the dominant regime across stories for the leverage context line; annotate a story in the breakdown when its regime differs from the project default. (`estimated_hours_pre_bcp` stays ignored.)
+   - **`cohort_drift(category, segment)`** (v0.7 — the shared primitive for estimation-time drift alerts; also consumed by `bmad-pulse-track-start`). For a **cohort**, the **median** of the per-story estimate error `|actual_hours - estimated_hours| / estimated_hours * 100` over the **last `K = 5` completed stories** in that cohort (story-order = chronological proxy; floor `estimated_hours` at 0.01). For BCP stories this equals `|bcp_recorded.drift_pct|`. The **cohort key** is `(category, segment)` when the story carries BCP (segment = `micro`/`story` from the v0.5 median split), else `(category)` alone — fallback documented so non-BCP projects still cohort by category. Returns `(median_abs_drift_pct, n, sample_story_ids)` where `n` is the cohort size considered (≤ K). **Requires `n >= 3`** to be meaningful — fewer → `insufficient` (callers must stay silent, no false alarm). This is read-only over `pulse_metrics`; it never writes or alters any estimate.
+   - **`drift_watchlist`** (v0.7) — the forward-looking companion to the track-start alert. For **every** cohort present in `pulse_metrics`, evaluate `cohort_drift`; keep only cohorts with `n >= 3` **and** `median_abs_drift_pct > T = 25%`, sorted by `median_abs_drift_pct` desc. Each entry carries `(cohort_label, median_abs_drift_pct, n, trend)` where `trend` reuses the v0.6 half-split direction (`↓`/`→`/`↑`). Healthy cohorts (≤ T) are omitted. Empty list is the healthy default.
    - Average, minimum, and maximum leverage
    - Total estimated hours vs total actual hours
    - First-pass rate
@@ -249,6 +251,20 @@ Epic {N}: {bcp} BCP ({count} stories)
 > (`bcp.breakdown`) is owned by `bmad-module-bcp` and is intentionally not
 > read here — this preserves zero coupling.
 <!-- END CONDITIONAL bcp -->
+
+## 🚦 Estimation drift watch
+
+> Forward-looking companion to the track-start alert: which cohorts are estimating badly *right now*, so you can re-estimate before committing. A cohort is listed only when it has ≥3 completed stories and its median estimate error exceeds 25% over the last 5. Healthy cohorts are omitted.
+
+{if drift_watchlist non-empty}
+| Cohort | Median \|drift\| | n | Trend |
+| ------ | -------------- | - | ----- |
+{for each (cohort_label, median_abs_drift_pct, n, trend) in drift_watchlist}
+| {cohort_label} | {median_abs_drift_pct}% | {n} | {trend} |
+{end}
+{else}
+_No cohorts drifting — estimates are tracking._
+{end}
 
 ## 💡 Process Insights
 

--- a/skills/bmad-pulse-track-start/workflow.md
+++ b/skills/bmad-pulse-track-start/workflow.md
@@ -142,7 +142,31 @@ Load the `pulse` section from `{main_config}` and resolve module variables:
    configured method, `bcp_at_start` is added alongside). When no valid `bcp:` block is
    present, omit both fields entirely — behave exactly as today.
 
-### Step 4: Confirm
+### Step 4: Estimation drift check (advisory — non-blocking)
+
+This is the v0.7 "action that matters": surface drift at the commitment gate so a
+bad estimate can be caught *before* it becomes a promise. Compute
+`cohort_drift(category, segment)` from the existing `pulse_metrics:` history (see
+the `bmad-pulse-dashboard` aggregation for the canonical definition):
+
+- **Segment** (only when a `bcp.total` was captured this run): `micro` if
+  `bcp.total < median(bcp.total over recorded stories)`, else `story`. Without
+  BCP, the cohort is `category` alone (documented fallback).
+- **Cohort drift**: the **median `|estimate error|%`** over the **last `K = 5`**
+  completed stories in the cohort (a completed story has both `estimated_hours`
+  and a recorded `actual_hours`/drift). For BCP stories this equals
+  `|bcp_recorded.drift_pct|`.
+- **Emit the advisory only when `n >= 3` and the median exceeds `T = 25%`.**
+  Otherwise stay **silent** — no false alarm on a healthy or thin cohort.
+
+The advisory is **non-blocking**: a one-line heads-up in the Confirm card. The
+start is recorded regardless and PULSE **never changes `estimated_hours`** — the
+re-estimate decision is the human's/agent's. Defaults `K=5` / `T=25%` are inline
+(may become config later).
+
+> **Advisory invariant (do not regress).** Estimation is owned **upstream** (BMAD/Amelia, or BCP/Bruno) — PULSE stays passive. This alert **informs, it never drives**: it reads `pulse_metrics` history, it never writes the story frontmatter, never writes or adjusts `estimated_hours`, never halts the start, and never re-scores anything. If a future edit makes it mutate an estimate or block the flow, that breaks the contract (locked by `tests/test_action_alert.py`).
+
+### Step 5: Confirm
 
 Display:
 
@@ -154,6 +178,7 @@ Display:
    {if bcp_at_start}BCP: {bcp_at_start.total} pts (rule {bcp_at_start.rule_version}, scored by {bcp_at_start.scored_by}){end}
    Tasks: {task_count}
    Category: {category}
+   {if cohort_drift alert (n >= 3 and median > 25%)}⚠ Heads up: stories like {category}{if segment}/{segment}{end} were off +{median_abs_drift}% (median) over the last {K} — re-estimate before committing? (advisory; PULSE will not change your estimate){end}
    ⏱️ The clock is running...
 ```
 
@@ -163,6 +188,7 @@ Display:
 
 - DO NOT modify anything outside the `pulse_metrics:` section of the sprint-status file
 - DO NOT write to the story file frontmatter or to any BCP baseline file — `bcp.*` is read-only input owned by `bmad-module-bcp`
+- The v0.7 drift advisory (Step 4) is **advisory-only and non-blocking**: it NEVER writes or changes `estimated_hours`, never auto-adjusts the estimate, and never halts the start. It only surfaces a heads-up; the re-estimate decision belongs to the human/agent.
 - If an entry already exists for this story ID in `pulse_metrics:`, ask whether to overwrite
 - Create the `pulse_metrics:` section if it does not exist
 - Communicate in the language configured in `communication_language`

--- a/tests/test_action_alert.py
+++ b/tests/test_action_alert.py
@@ -1,0 +1,185 @@
+"""Invariant tests for the v0.7 'action that matters' milestone.
+
+v0.7 surfaces drift at the *commitment gate* (track-start) so a bad estimate is
+interrupted before it becomes a promise. The math lives in agent instructions
+(no Python compute layer), so these pin the cohort-drift primitive and, in later
+phases, the advisory-only invariant of the alert itself.
+
+Phase 1 scope: the shared cohort_drift aggregation. The track-start alert
+(Phase 2), the dashboard watch-list (Phase 3) and the advisory-only contract
+(Phase 4) get their own invariants when they land.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[1]
+DASHBOARD = REPO_ROOT / "skills/bmad-pulse-dashboard/workflow.md"
+TRACK_START = REPO_ROOT / "skills/bmad-pulse-track-start/workflow.md"
+
+
+def test_cohort_drift_primitive_is_defined():
+    """cohort_drift(category, segment) must be defined as the shared v0.7
+    primitive over the per-story estimate error."""
+    text = DASHBOARD.read_text()
+    assert "cohort_drift(category, segment)" in text
+    assert "|actual_hours - estimated_hours| / estimated_hours" in text
+    assert "median" in text.lower()
+
+
+def test_cohort_drift_uses_last_k5():
+    """The window is the last K=5 completed stories in the cohort."""
+    text = DASHBOARD.read_text()
+    assert "K = 5" in text
+    assert "last `K = 5` completed stories" in text
+
+
+def test_cohort_key_is_category_segment_with_category_fallback():
+    """Cohort key = (category, segment) when the story carries BCP, else
+    (category) — so non-BCP projects still cohort by category."""
+    text = DASHBOARD.read_text()
+    assert "(category, segment)` when the story carries BCP" in text
+    assert "(category)` alone" in text
+
+
+def test_cohort_drift_insufficient_below_3():
+    """n<3 must be 'insufficient' and callers must stay silent — no false
+    alarm on a thin cohort."""
+    text = DASHBOARD.read_text()
+    assert "n >= 3" in text
+    assert "insufficient" in text.lower()
+    assert "no false alarm" in text.lower()
+
+
+def test_cohort_drift_is_read_only():
+    """The primitive reads pulse_metrics; it never writes or alters an
+    estimate (sets up the advisory-only invariant locked in Phase 4)."""
+    text = DASHBOARD.read_text()
+    assert "read-only over `pulse_metrics`" in text
+    assert "never writes or alters any estimate" in text
+
+
+def test_cohort_drift_equals_drift_pct_for_bcp():
+    """For BCP stories the per-story error equals |bcp_recorded.drift_pct|, so
+    the primitive is consistent with the v0.5/v0.6 drift data, not a new metric."""
+    text = DASHBOARD.read_text()
+    assert "equals `|bcp_recorded.drift_pct|`" in text
+
+
+# --- Phase 2: drift alert at the track-start commitment gate -----------------
+
+
+def test_alert_fires_at_track_start():
+    """track-start must have an estimation drift check step and surface the
+    advisory in the Confirm card."""
+    text = TRACK_START.read_text()
+    assert "Estimation drift check" in text
+    assert "cohort_drift(category, segment)" in text
+    assert "re-estimate before committing" in text
+
+
+def test_alert_threshold_t25_window_k5():
+    """The alert fires only when n>=3 and the cohort median exceeds T=25% over
+    the last K=5 — quantifying the '+N%' the roadmap asks for."""
+    text = TRACK_START.read_text()
+    assert "n >= 3" in text and "T = 25%" in text and "K = 5" in text
+
+
+def test_alert_silent_when_healthy_or_thin():
+    """No false alarm: stay silent on a healthy or thin cohort."""
+    text = TRACK_START.read_text()
+    assert "silent" in text.lower()
+    assert "no false alarm" in text.lower()
+
+
+def test_alert_is_non_blocking():
+    """The advisory must be non-blocking — the start is recorded regardless."""
+    text = TRACK_START.read_text()
+    assert "non-blocking" in text.lower()
+    assert "start is recorded regardless" in text.lower() or "never halts the start" in text.lower()
+
+
+def test_alert_never_changes_the_estimate():
+    """Advisory-only invariant at the source: track-start never writes or
+    changes estimated_hours via the alert."""
+    text = TRACK_START.read_text()
+    assert "never changes `estimated_hours`" in text or "never writes or changes `estimated_hours`" in text
+    assert "advisory-only" in text.lower()
+
+
+# --- Phase 3: dashboard estimation-drift watch-list -------------------------
+
+
+def test_watchlist_aggregation_defined():
+    """drift_watchlist keeps only cohorts with n>=3 and median > T, sorted desc."""
+    text = DASHBOARD.read_text()
+    assert "drift_watchlist" in text
+    assert "median_abs_drift_pct > T = 25%" in text
+    assert "sorted by `median_abs_drift_pct` desc" in text
+
+
+def test_watchlist_section_rendered():
+    """The dashboard must render an 'Estimation drift watch' section."""
+    text = DASHBOARD.read_text()
+    assert "Estimation drift watch" in text
+    assert "| Cohort |" in text and "Trend" in text
+
+
+def test_watchlist_omits_healthy_and_has_empty_default():
+    """Healthy cohorts are omitted; an empty watch-list shows the healthy
+    default message, not a blank/alarming table."""
+    text = DASHBOARD.read_text()
+    assert "Healthy cohorts are omitted" in text
+    assert "No cohorts drifting — estimates are tracking" in text
+
+
+def test_watchlist_is_additive_outside_bcp_gate():
+    """The watch-list works for non-BCP projects too — it must sit OUTSIDE the
+    BCP conditional block (after END CONDITIONAL bcp)."""
+    text = DASHBOARD.read_text()
+    end_bcp = text.find("<!-- END CONDITIONAL bcp -->")
+    watch = text.find("## 🚦 Estimation drift watch")
+    assert end_bcp != -1 and watch != -1
+    assert watch > end_bcp, "watch-list must be outside the BCP-gated section"
+
+
+# --- Phase 4: advisory-only contract (consolidating lock) -------------------
+
+
+def test_advisory_invariant_note_present():
+    """The 'why' must live next to the code: track-start carries an explicit
+    advisory-invariant note (estimation is upstream; the alert informs, never
+    drives)."""
+    text = TRACK_START.read_text()
+    assert "Advisory invariant" in text
+    assert "informs, it never drives" in text
+    assert "owned **upstream**" in text
+
+
+def test_v07_never_writes_estimates_or_frontmatter():
+    """Cross-cutting lock: the v0.7 surfaces never mutate an estimate or the
+    story frontmatter. track-start states it for the alert; the dashboard
+    cohort primitive is read-only over pulse_metrics."""
+    ts = TRACK_START.read_text()
+    assert "never writes the story frontmatter" in ts
+    assert "never writes or adjusts `estimated_hours`" in ts
+    dash = DASHBOARD.read_text()
+    assert "read-only over `pulse_metrics`" in dash
+    assert "never writes or alters any estimate" in dash
+
+
+def test_alert_quantifies_plus_n_percent():
+    """Roadmap promise: the alert quantifies '+N%' (a number), not a vague
+    'drifting' label."""
+    ts = TRACK_START.read_text()
+    assert "+{median_abs_drift}%" in ts
+
+
+def test_alert_and_watchlist_share_one_primitive():
+    """Both the track-start alert and the dashboard watch-list must derive from
+    the same cohort_drift primitive — no divergent thresholds or definitions."""
+    assert "cohort_drift(category, segment)" in TRACK_START.read_text()
+    dash = DASHBOARD.read_text()
+    assert "cohort_drift(category, segment)" in dash and "drift_watchlist" in dash
+    # the threshold T=25% is stated once per consumer, identical value
+    assert "T = 25%" in TRACK_START.read_text() and "T = 25%" in dash


### PR DESCRIPTION
## v0.7 — A ação que importa

Leva o sinal de drift pro **momento do compromisso**. v0.5/v0.6 são retrospectivas (você vê o drift depois que a story fechou); a v0.7 avisa **ao iniciar a story** se a coorte dela vem errando a estimativa — antes de virar promessa. PULSE segue passivo: o alerta **informa, nunca dirige**, e nunca altera `estimated_hours`. **Aditivo, não-breaking.**

### O que mudou (4 fases)

| Fase | Mudança |
|------|---------|
| **1 — Primitivo** | `cohort_drift(category, segment)`: mediana do erro de estimativa `\|actual−estimated\|/estimated` das últimas **K=5** da coorte. Coorte = `category + segmento` (micro/story da v0.5) com BCP, fallback `category`. `n≥3` ou `insufficient`. Read-only sobre `pulse_metrics`; pra BCP equivale a `\|drift_pct\|`. |
| **2 — Alerta no track-start** | Novo Step 4 (advisory, **não-bloqueante**). Se a coorte tem `n≥3` e mediana `> 25%`: `⚠ stories like X were off +N% over the last 5 — re-estimate before committing?` no card. O start é registrado normal; `estimated_hours` nunca muda. |
| **3 — Watch-list no dashboard** | Nova seção `🚦 Estimation drift watch` lista coortes com drift `> 25%`, ordenadas, com tendência. Saudáveis omitidas; tudo saudável → "No cohorts drifting". Aditiva, fora do gate BCP. |
| **4 — Contract test advisory-only** | Trava que nenhuma superfície v0.7 escreve a estimativa/frontmatter ou bloqueia o fluxo; alerta e watch-list compartilham **um** primitivo. |

### Decisões de design (resolvidas no plano)

- **Gatilho no track-start** (gate de compromisso PULSE-native), não-bloqueante — não acopla PULSE no fluxo de estimativa upstream.
- **Coorte = category + segment** (fallback category) — reusa a segmentação da v0.5; "stories como X" = mesma categoria e tamanho.
- **K=5, T=25%, min 3, inline** — quantifica o "+N%" do roadmap; evita scope creep de config (como na v0.6).
- **Advisory-only travado por contract test** — PULSE nunca escreve `estimated_hours`; estimativa é upstream.

### Testes

19 testes novos em `tests/test_action_alert.py` (invariantes sobre o markdown dos workflows + locks de contrato). **Suíte completa: 192 verde** (v0.5/v0.6 + golden parity intactos).

### Release

**Aditivo, não-breaking** → `feat:` puro pré-1.0 bumparia patch (0.6.1). Pra manter alinhamento roadmap↔semver em **v0.7.0**, o commit carrega `Release-As: 0.7.0`. Notas em `docs/MIGRATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
