### PR TITLE
feat(dashboard): saída do dashboard em PT-BR (jargão mantido)

### DIFF
--- a/examples/dashboards/mature-bmad-team.md
+++ b/examples/dashboards/mature-bmad-team.md
@@ -1,24 +1,24 @@
-# ⚡ PULSE — Efficiency Dashboard
+# ⚡ PULSE — Dashboard de Eficiência
 
 > Process Utilization & Leverage Statistics Engine
-> Generated at: 2026-04-28 22:46 | Project: SIP
+> Gerado em: 2026-04-28 22:46 | Projeto: SIP
 
 ---
 
-## 🏆 General Statistics
+## 🏆 Estatísticas Gerais
 
-| Metric                  | Value     |
+| Métrica                 | Valor     |
 | ----------------------- | --------- |
-| Stories measured        | 12        |
-| Avg AI Leverage         | **6.9x**  |
-| Human estimated hours   | 152h      |
-| Actual AI hours         | 22h       |
-| Hours saved             | **130h**  |
-| First-pass rate         | 83%       |
+| Stories medidas         | 12        |
+| AI Leverage médio       | **6.9x**  |
+| Horas estimadas (humano)| 152h      |
+| Horas reais (IA)        | 22h       |
+| Horas economizadas      | **130h**  |
+| Taxa de first-pass      | 83%       |
 
-## 📈 Leverage Trend by Epic
+## 📈 Tendência de Leverage por Epic
 
-Sparkline: each █ = 0.5x leverage, maximum 20 characters.
+Sparkline: cada █ = 0.5x de leverage, máximo 20 caracteres.
 
 ```text
 Epic  1: ████████░░░░░░░░░░░░  4.2x (3 stories)
@@ -28,51 +28,51 @@ Epic 14: ██████████████░░░░░░  6.9x (3 s
 Epic 15: ████████████████████  8.4x (1 story)
 ```
 
-## 📊 Leverage by Category
+## 📊 Leverage por Categoria
 
-| Category   | Avg Leverage | Stories | Best  |
-| ---------- | ------------ | ------- | ----- |
-| backend    | 7.2x         | 4       | 8.4x  |
-| web        | 6.5x         | 3       | 7.8x  |
-| mobile     | 5.8x         | 2       | 6.9x  |
-| fullstack  | **7.8x**     | 3       | 9.1x  |
+| Categoria  | Leverage médio | Stories | Melhor |
+| ---------- | -------------- | ------- | ------ |
+| backend    | 7.2x           | 4       | 8.4x   |
+| web        | 6.5x           | 3       | 7.8x   |
+| mobile     | 5.8x           | 2       | 6.9x   |
+| fullstack  | **7.8x**       | 3       | 9.1x   |
 
-## 🔮 Capacity Forecast
+## 🔮 Previsão de Capacidade
 
-Based on avg leverage of 6.9x:
+Baseado no leverage médio de 6.9x:
 
-- 10h estimated → ~1.4h actual
-- 40h estimated → ~5.8h actual
-- 80h estimated → ~11.6h actual
+- 10h estimadas → ~1.4h reais
+- 40h estimadas → ~5.8h reais
+- 80h estimadas → ~11.6h reais
 
-## 💡 Process Insights
+## 💡 Insights de Processo
 
-⚡ **Levi:** Time operating at 6.9x average leverage — well past the 3.0x exceptional threshold. Three strong signals:
+⚡ **Levi:** Operando a 6.9x de leverage médio — bem além do limiar excepcional de 3.0x. Três sinais fortes:
 
-1. **Fullstack stories are your highest leverage** (7.8x avg). The compounding gain when AI handles cross-layer scaffolding is real. Document the workflow.
-2. **First-pass rate of 83%** means quality stays high even as speed climbs. AI isn't trading rigor for velocity — it's amplifying both.
-3. **Epic 15 hit 8.4x on a single story** — outlier worth studying. What was different? Replicate it.
+1. **Stories fullstack são seu maior leverage** (7.8x médio). O ganho composto quando a IA cuida do scaffolding cross-layer é real. Documente o workflow.
+2. **Taxa de first-pass de 83%** significa que a qualidade se mantém alta mesmo com a velocidade subindo. A IA não troca rigor por velocidade — amplifica os dois.
+3. **Epic 15 chegou a 8.4x numa única story** — outlier que vale estudar. O que foi diferente? Replique.
 
-⚠ **Watch:** 2 stories show `pulse-track-start` invoked retroactively. Hook it into `/bmad-dev-story` to capture clean start timestamps automatically.
+⚠ **Atenção:** 2 stories mostram `pulse-track-start` invocado retroativamente. Conecte ao `/bmad-dev-story` pra capturar timestamps de início limpos automaticamente.
 
-## 📋 Story Breakdown
+## 📋 Detalhamento por Story
 
-| Story                                      | Est.  | Actual | Leverage | Quality | Category   |
-| ------------------------------------------ | ----- | ------ | -------- | ------- | ---------- |
-| 1.1 login-supabase-auth                    | 8h    | 2.1h   | 3.8x     | ✅ pass | backend    |
-| 1.3 download-cache-usuarios                | 6h    | 1.4h   | 4.3x     | ✅ pass | backend    |
-| 4.4 coresync-pull-bidirectional            | 14h   | 2.8h   | 5.0x     | ✅ pass | backend    |
-| 4.6 coresync-ack-mobile                    | 10h   | 1.9h   | 5.3x     | 🔁 1x   | mobile     |
-| 5.3 projetos-crud-list                     | 12h   | 1.6h   | 7.5x     | ✅ pass | fullstack  |
-| 5.8-mvp publish-flag                       | 15h   | 1.92h  | **7.8x** | ✅ pass | fullstack  |
-| 5.9 importacao-questionarios               | 18h   | 2.4h   | 7.5x     | ✅ pass | fullstack  |
-| 14.1 role-impersonator-endpoint            | 16h   | 2.3h   | 7.0x     | ✅ pass | backend    |
-| 14.5 audit-log-completo-lgpd               | 12h   | 1.7h   | 7.1x     | ✅ pass | backend    |
-| 14.8 remocao-customer-select               | 10h   | 1.5h   | 6.7x     | ✅ pass | web        |
-| 15.2 migrar-crud-clientes-admin            | 14h   | 1.8h   | 7.8x     | 🔁 1x   | web        |
-| 15.4 dashboard-visao-geral-plataforma      | 17h   | 2.0h   | **8.4x** | ✅ pass | web        |
+| Story                                      | Est.  | Real   | Leverage | Qualidade | Categoria  |
+| ------------------------------------------ | ----- | ------ | -------- | --------- | ---------- |
+| 1.1 login-supabase-auth                    | 8h    | 2.1h   | 3.8x     | ✅ passou | backend    |
+| 1.3 download-cache-usuarios                | 6h    | 1.4h   | 4.3x     | ✅ passou | backend    |
+| 4.4 coresync-pull-bidirectional            | 14h   | 2.8h   | 5.0x     | ✅ passou | backend    |
+| 4.6 coresync-ack-mobile                    | 10h   | 1.9h   | 5.3x     | 🔁 1x     | mobile     |
+| 5.3 projetos-crud-list                     | 12h   | 1.6h   | 7.5x     | ✅ passou | fullstack  |
+| 5.8-mvp publish-flag                       | 15h   | 1.92h  | **7.8x** | ✅ passou | fullstack  |
+| 5.9 importacao-questionarios               | 18h   | 2.4h   | 7.5x     | ✅ passou | fullstack  |
+| 14.1 role-impersonator-endpoint            | 16h   | 2.3h   | 7.0x     | ✅ passou | backend    |
+| 14.5 audit-log-completo-lgpd               | 12h   | 1.7h   | 7.1x     | ✅ passou | backend    |
+| 14.8 remocao-customer-select               | 10h   | 1.5h   | 6.7x     | ✅ passou | web        |
+| 15.2 migrar-crud-clientes-admin            | 14h   | 1.8h   | 7.8x     | 🔁 1x     | web        |
+| 15.4 dashboard-visao-geral-plataforma      | 17h   | 2.0h   | **8.4x** | ✅ passou | web        |
 
 ---
 
-_PULSE — Against facts, there are no arguments._  
-_Dashboard generated automatically by the PULSE module._
+_PULSE — Contra fatos, não há argumentos._  
+_Dashboard gerado automaticamente pelo módulo PULSE._

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -117,111 +117,111 @@ Generate the dashboard in the format(s) defined in `pulse_dashboard_format` (`ma
 For `markdown` format (default), write `{dashboard_file}` with the following structure:
 
 ```markdown
-# ⚡ PULSE — Efficiency Dashboard
+# ⚡ PULSE — Dashboard de Eficiência
 
 > Process Utilization & Leverage Statistics Engine
-> Generated at: {date} | Project: {project_name}
+> Gerado em: {date} | Projeto: {project_name}
 
 ---
 
-## 🏆 General Statistics
+## 🏆 Estatísticas Gerais
 
-| Metric                  | Value                                |
+| Métrica                 | Valor                                |
 | ----------------------- | ------------------------------------ |
-| Stories measured        | {total}                              |
-| **Predictability**      | **{predictability_score}% off (median) {trend_arrow}** |
-| Human estimated hours   | {total_estimated}h                   |
-| Actual AI hours         | {total_actual}h                      |
-| Hours saved             | {saved}h                             |
-| First-pass rate         | {rate}%                              |
-| AI Leverage (vs PLAN, {dominant_regime}) | {avg}x — context, not a target |
+| Stories medidas         | {total}                              |
+| **Previsibilidade**     | **{predictability_score}% de erro (mediana) {trend_arrow}** |
+| Horas estimadas (humano)| {total_estimated}h                   |
+| Horas reais (IA)        | {total_actual}h                      |
+| Horas economizadas      | {saved}h                             |
+| Taxa de first-pass      | {rate}%                              |
+| AI Leverage (vs PLANO, {dominant_regime}) | {avg}x — contexto, não meta |
 
-> **Predictability is the hero number** (lower = estimates closer to reality; `↓` = converging). Leverage is shown as context only and read "vs PLAN ({dominant_regime})", never "vs human" — the regime is the estimate basis (`estimated_hours_basis`, read-only) so the multiplier is read against the right plan. A high multiplier signals an uncalibrated estimate basis, not speed (see the anti-Goodhart invariant below).
+> **Previsibilidade é o número-herói** (menor = estimativas mais perto da realidade; `↓` = convergindo). Leverage aparece só como contexto e lê-se "vs PLANO ({dominant_regime})", nunca "vs humano" — o regime é a base da estimativa (`estimated_hours_basis`, read-only), pra o multiplicador ser lido contra o plano certo. Um multiplicador alto sinaliza base de estimativa não-calibrada, não velocidade (veja o invariante anti-Goodhart abaixo).
 
-> **Anti-Goodhart invariant — leverage is not a target.** `leverage = estimated_hours / actual_hours`. Once the estimate basis is calibrated (estimates derived from a baseline that matches reality), this ratio collapses to **~1.0x by construction** — so a *high* multiplier signals an inflated or uncalibrated estimate basis, **not** velocity, and a *leverage goal* would literally reward never calibrating. The durable signal is **predictability**: the per-category h/BCP drift converging on zero (do estimates match outcomes?). Read every multiplier as "vs PLAN", never "vs human". (v0.5 locked this invariant; v0.6 acted on it — predictability now leads the dashboard and the track-done celebration triggers on accuracy, not leverage magnitude.)
+> **Invariante anti-Goodhart — leverage não é meta.** `leverage = estimated_hours / actual_hours`. Quando a base de estimativa está calibrada (estimativas derivadas de um baseline que casa com a realidade), essa razão colapsa pra **~1.0x por construção** — então um multiplicador *alto* sinaliza base de estimativa inflada ou não-calibrada, **não** velocidade, e uma *meta de leverage* literalmente premiaria nunca calibrar. O sinal durável é a **previsibilidade**: o drift de h/BCP por categoria convergindo a zero (as estimativas casam com os resultados?). Leia todo multiplicador como "vs PLANO", nunca "vs humano". (v0.5 travou esse invariante; v0.6 agiu sobre ele — a previsibilidade agora lidera o dashboard e a celebração do track-done dispara por acurácia, não por magnitude de leverage.)
 
 <!-- CONDITIONAL: include only if pulse_include_trend_chart == yes -->
-## 📈 Leverage Trend by Epic
+## 📈 Tendência de Leverage por Epic
 
-Sparkline: each █ = 0.5x leverage, maximum 20 characters.
+Sparkline: cada █ = 0.5x de leverage, máximo 20 caracteres.
 
 {for each epic with data}
 Epic {N}: {sparkline} {avg}x ({count} stories)
 {end}
 
-Example: Epic 14: ████████░░ 3.5x (4 stories)
+Exemplo: Epic 14: ████████░░ 3.5x (4 stories)
 <!-- END CONDITIONAL trend_chart -->
 
-## 📊 Leverage by Category
+## 📊 Leverage por Categoria
 
-| Category | Avg Leverage (vs PLAN) | Stories | Best |
-| -------- | ---------------------- | ------- | ---- |
+| Categoria | Leverage médio (vs PLANO) | Stories | Melhor |
+| --------- | ------------------------- | ------- | ------ |
 {for each category in pulse_dev_categories}
 | {category} | {x}x | {n} | {best} |
 {end}
 
 <!-- CONDITIONAL: include only if pulse_include_capacity_forecast == yes -->
-## 🔮 Capacity Forecast
+## 🔮 Previsão de Capacidade
 
-Based on avg leverage of {avg}x:
+Baseado no leverage médio de {avg}x:
 
-- 10h estimated → ~{10/avg}h actual
-- 40h estimated → ~{40/avg}h actual
-- 80h estimated → ~{80/avg}h actual
+- 10h estimadas → ~{10/avg}h reais
+- 40h estimadas → ~{40/avg}h reais
+- 80h estimadas → ~{80/avg}h reais
 <!-- END CONDITIONAL capacity_forecast -->
 
 <!-- CONDITIONAL: include only if total_approval_wait_count > 0 OR total_pre_approved_batch_count > 0 -->
-## ⏸ Approval-Wait Halts
+## ⏸ Pausas de Aprovação (Approval-Wait)
 
-| Metric                                  | Value                              |
+| Métrica                                 | Valor                              |
 | --------------------------------------- | ---------------------------------- |
-| Approval-wait halts (subtracted)        | {total_approval_wait_count}        |
-| Total approval-wait time subtracted     | {total_approval_wait_minutes}min   |
-| Pre-approved batch decisions (skipped)  | {total_pre_approved_batch_count}   |
+| Pausas de aprovação (subtraídas)        | {total_approval_wait_count}        |
+| Tempo total de aprovação subtraído      | {total_approval_wait_minutes}min   |
+| Decisões de batch pré-aprovadas (puladas)| {total_pre_approved_batch_count}  |
 
 {if stories_with_approval_wait}
-**By story:**
+**Por story:**
 
-| Story | Approval-wait minutes |
-| ----- | --------------------- |
+| Story | Minutos de aprovação |
+| ----- | -------------------- |
 {for each (story_id, minutes) in stories_with_approval_wait}
 | {story_id} | {minutes}min |
 {end}
 {end}
 
-> Approval-wait halts measure governance latency (human-in-the-loop decisions) and are subtracted from `actual_hours` so leverage reflects real dev work, not wait time. `pre_approved_batch` flags durable decisions that legitimately remove latency on subsequent stories — these are reported but not subtracted.
+> Pausas de aprovação medem latência de governança (decisões human-in-the-loop) e são subtraídas de `actual_hours` pra o leverage refletir trabalho real de dev, não tempo de espera. `pre_approved_batch` marca decisões duráveis que legitimamente removem latência em stories seguintes — essas são reportadas, mas não subtraídas.
 
 {if legacy_halt_string_count > 0}
-> ⚠ {legacy_halt_string_count} legacy halt entries (plain strings, pre-0.5.0 format) were detected. Their durations are not machine-readable and were excluded from minute totals. Migrate these entries to the structured shape (with `kind`, `context`, `duration_min`) for accurate leverage on historical stories.
+> ⚠ {legacy_halt_string_count} entradas de halt legadas (strings simples, formato pré-0.5.0) foram detectadas. As durações não são legíveis por máquina e foram excluídas dos totais de minutos. Migre essas entradas pro formato estruturado (com `kind`, `context`, `duration_min`) pra leverage acurado nas stories históricas.
 {end}
 <!-- END CONDITIONAL approval_wait -->
 
 <!-- CONDITIONAL: include only if bcp_stories is non-empty (≥1 story has a bcp_recorded block) -->
-## 📊 BCP Productivity
+## 📊 Produtividade BCP
 
-> Business Complexity Points telemetry. Hours were derived upstream by
-> [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp); PULSE only
-> reports observed productivity and never owns the BCP baseline.
+> Telemetria de Business Complexity Points. As horas foram derivadas upstream pelo
+> [`bmad-module-bcp`](https://github.com/nidelson/bmad-module-bcp); PULSE só
+> reporta produtividade observada e nunca é dono do baseline BCP.
 
-| Metric                | Value          |
+| Métrica               | Valor          |
 | --------------------- | -------------- |
-| Stories with BCP      | {len(bcp_stories)} |
-| Total BCP scored      | {total_bcp}    |
+| Stories com BCP       | {len(bcp_stories)} |
+| Total BCP pontuado    | {total_bcp}    |
 
-**Throughput (BCP per epic):**
+**Throughput (BCP por epic):**
 
 {for each epic in bcp_throughput}
 Epic {N}: {bcp} BCP ({count} stories)
 {end}
 
-**Actual h/BCP by category and size segment:**
+**h/BCP real por categoria e segmento de tamanho:**
 
-> Stories split at the observed median BCP (`segment_split` = {segment_split} BCP): below it = `micro`, at/above = `story`. The `all` row pools both, for continuity with pre-0.5 dashboards. A segment with fewer than 3 stories is folded into `all` rather than shown on its own (too thin to trust).
+> Stories divididas na mediana de BCP observada (`segment_split` = {segment_split} BCP): abaixo = `micro`, igual/acima = `story`. A linha `all` agrupa as duas, pra continuidade com dashboards pré-0.5. Um segmento com menos de 3 stories é dobrado em `all` em vez de mostrado sozinho (fino demais pra confiar).
 >
-> The `Actual h/BCP` cell shows the geometric mean with its **typical range** `[low–high]` (≈68%, sample GSD, `k=1`). The range is shown only when `n >= 3`; for `n < 3` the bare point is shown (its `n` is in the `n` column — too few samples for a trustworthy range).
+> A célula `h/BCP real` mostra a média geométrica com sua **faixa típica** `[low–high]` (≈68%, GSD amostral, `k=1`). A faixa só aparece quando `n >= 3`; pra `n < 3` mostra o ponto puro (o `n` está na coluna `n` — amostras de menos pra uma faixa confiável).
 
-| Category | Segment | n | Actual h/BCP (typical range) | Est. h/BCP | Drift |
-| -------- | ------- | - | ---------------------------- | ---------- | ----- |
+| Categoria | Segmento | n | h/BCP real (faixa típica) | h/BCP est. | Drift |
+| --------- | -------- | - | ------------------------- | ---------- | ----- |
 {for each category with bcp_stories}
 {for each segment in [micro, story] with n >= 3}
 | {category} | {segment} | {n} | {h_per_bcp_by_category}h [{band.low}–{band.high}] | {h_per_bcp_estimated_by_category}h | {drift:+}% |
@@ -229,51 +229,51 @@ Epic {N}: {bcp} BCP ({count} stories)
 | {category} | all | {n_all} | {pooled h_per_bcp_by_category}h{if n_all >= 3} [{pooled band.low}–{pooled band.high}]{end} | {pooled h_per_bcp_estimated_by_category}h | {drift:+}% |
 {end}
 
-**Baseline convergence (is h/BCP stabilizing?):**
+**Convergência do baseline (h/BCP está estabilizando?):**
 
-> {if bcp_stories count >= 4}**{h_per_bcp_convergence}** — median |drift| moved from {first_half_median}% (first half) to {second_half_median}% (second half); the confidence band {band narrowed / widened / held} over the same split. Converging is the healthy direction: estimates closing on reality.{else}_Insufficient data (thin sample — need ≥4 BCP stories for a convergence reading)._{end}
+> {if bcp_stories count >= 4}**{h_per_bcp_convergence}** — a mediana de |drift| foi de {first_half_median}% (1ª metade) pra {second_half_median}% (2ª metade); a faixa de confiança {band narrowed / widened / held} no mesmo split. Convergir é a direção saudável: estimativas se fechando na realidade.{else}_Dados insuficientes (amostra fina — precisa de ≥4 stories BCP pra uma leitura de convergência)._{end}
 
-**Drift trend (estimated vs actual h/BCP):**
+**Tendência de drift (h/BCP estimado vs real):**
 
 {for each (story_id, drift_pct) in drift_trend}
 {story_id}: {drift_pct:+}%
 {end}
 
-**Top stories by BCP:**
+**Top stories por BCP:**
 
-| Story | BCP | Actual h/BCP |
-| ----- | --- | ------------ |
+| Story | BCP | h/BCP real |
+| ----- | --- | ---------- |
 {for each story in top_bcp_stories}
 | {story_id} | {bcp_recorded.total} | {bcp_recorded.h_per_bcp_actual}h |
 {end}
 
-> Note: PULSE ranks by story-level BCP total. Per-element breakdown
-> (`bcp.breakdown`) is owned by `bmad-module-bcp` and is intentionally not
-> read here — this preserves zero coupling.
+> Nota: PULSE ranqueia pelo total de BCP por story. O detalhamento por elemento
+> (`bcp.breakdown`) é do `bmad-module-bcp` e é intencionalmente não
+> lido aqui — isso preserva o zero coupling.
 <!-- END CONDITIONAL bcp -->
 
-## 🚦 Estimation drift watch
+## 🚦 Monitor de drift de estimativa
 
-> Forward-looking companion to the track-start alert: which cohorts are estimating badly *right now*, so you can re-estimate before committing. A cohort is listed only when it has ≥3 completed stories and its median estimate error exceeds 25% over the last 5. Healthy cohorts are omitted.
+> Companheiro prospectivo do alerta do track-start: quais coortes estão estimando mal *agora*, pra você reestimar antes de se comprometer. Uma coorte só é listada quando tem ≥3 stories concluídas e seu erro de estimativa mediano passa de 25% nas últimas 5. Coortes saudáveis são omitidas.
 
 {if drift_watchlist non-empty}
-| Cohort | Median \|drift\| | n | Trend |
-| ------ | -------------- | - | ----- |
+| Coorte | Mediana \|drift\| | n | Tendência |
+| ------ | --------------- | - | --------- |
 {for each (cohort_label, median_abs_drift_pct, n, trend) in drift_watchlist}
 | {cohort_label} | {median_abs_drift_pct}% | {n} | {trend} |
 {end}
 {else}
-_No cohorts drifting — estimates are tracking._
+_Nenhuma coorte derivando — estimativas no rumo._
 {end}
 
-## 💡 Process Insights
+## 💡 Insights de Processo
 
-{insights generated based on the data}
+{insights gerados a partir dos dados}
 
-## 📋 Story Breakdown
+## 📋 Detalhamento por Story
 
-| Story | Est. | Actual | Leverage (vs PLAN) | Quality | Category |
-| ----- | ---- | ------ | ------------------ | ------- | -------- |
+| Story | Est. | Real | Leverage (vs PLANO) | Qualidade | Categoria |
+| ----- | ---- | ---- | ------------------- | --------- | --------- |
 
 {for each story with pulse_metrics data}
 | {id} | {est}h | {actual}h | {lev}x | {quality} | {cat} |
@@ -281,8 +281,8 @@ _No cohorts drifting — estimates are tracking._
 
 ---
 
-_PULSE — Against facts, there are no arguments._
-_Dashboard generated automatically by the PULSE module._
+_PULSE — Contra fatos, não há argumentos._
+_Dashboard gerado automaticamente pelo módulo PULSE._
 ```
 
 For `yaml` format, generate `{pulse_dashboard_folder}/dashboard.yaml` with the same data structured as YAML.
@@ -297,8 +297,8 @@ The detail level of the summary must respect `pulse_levi_verbosity`.
 ### Step 4: Report Location
 
 ```text
-⚡ Levi: Dashboard saved at {dashboard_file}
-   {total} stories measured | Avg leverage: {avg}x
+⚡ Levi: Dashboard salvo em {dashboard_file}
+   {total} stories medidas | Leverage médio: {avg}x
 ```
 
 ---
@@ -308,6 +308,7 @@ The detail level of the summary must respect `pulse_levi_verbosity`.
 - If no data exists in the `pulse_metrics:` section, inform and suggest running track-start/track-done first
 - Create the `{pulse_dashboard_folder}` directory if it does not exist
 - Always overwrite dashboard.md (it is the most recent version)
+- The rendered dashboard template above is **PT-BR by default** (section titles, table headers, labels, messages, notes). Keep all technical jargon in English (`h/BCP`, `BCP`, `leverage`, `drift`, `micro`/`story`, field names) and every `{placeholder}` verbatim. If `communication_language` is set to another language, localize the rendered labels/messages accordingly (jargon and placeholders still unchanged); the internal aggregation logic in Step 1 stays English regardless.
 - Communicate in the language configured in `communication_language`
 - Respect `pulse_levi_verbosity` for level of detail in responses
 - The leverage trend section must only be included if `pulse_include_trend_chart == yes`

--- a/tests/test_action_alert.py
+++ b/tests/test_action_alert.py
@@ -119,18 +119,19 @@ def test_watchlist_aggregation_defined():
 
 
 def test_watchlist_section_rendered():
-    """The dashboard must render an 'Estimation drift watch' section."""
+    """The dashboard must render the 'Monitor de drift de estimativa' section
+    (PT-BR rendered output)."""
     text = DASHBOARD.read_text()
-    assert "Estimation drift watch" in text
-    assert "| Cohort |" in text and "Trend" in text
+    assert "Monitor de drift de estimativa" in text
+    assert "| Coorte |" in text and "Tendência" in text
 
 
 def test_watchlist_omits_healthy_and_has_empty_default():
     """Healthy cohorts are omitted; an empty watch-list shows the healthy
-    default message, not a blank/alarming table."""
+    default message, not a blank/alarming table (PT-BR rendered output)."""
     text = DASHBOARD.read_text()
-    assert "Healthy cohorts are omitted" in text
-    assert "No cohorts drifting — estimates are tracking" in text
+    assert "Coortes saudáveis são omitidas" in text
+    assert "Nenhuma coorte derivando — estimativas no rumo" in text
 
 
 def test_watchlist_is_additive_outside_bcp_gate():
@@ -138,7 +139,7 @@ def test_watchlist_is_additive_outside_bcp_gate():
     BCP conditional block (after END CONDITIONAL bcp)."""
     text = DASHBOARD.read_text()
     end_bcp = text.find("<!-- END CONDITIONAL bcp -->")
-    watch = text.find("## 🚦 Estimation drift watch")
+    watch = text.find("## 🚦 Monitor de drift de estimativa")
     assert end_bcp != -1 and watch != -1
     assert watch > end_bcp, "watch-list must be outside the BCP-gated section"
 

--- a/tests/test_anti_goodhart.py
+++ b/tests/test_anti_goodhart.py
@@ -54,17 +54,17 @@ def test_leverage_formula_is_estimated_over_actual():
 def test_dashboard_carries_anti_goodhart_note():
     """The 'why' must live next to the leverage number on the dashboard."""
     text = DASHBOARD.read_text()
-    assert "Anti-Goodhart invariant" in text
-    assert "leverage is not a target" in text.lower()
-    assert "~1.0x by construction" in text
-    assert "vs PLAN" in text and "never" in text and "vs human" in text
+    assert "Invariante anti-Goodhart" in text
+    assert "leverage não é meta" in text.lower()
+    assert "~1.0x por construção" in text
+    assert "vs PLANO" in text and "nunca" in text and "vs humano" in text
 
 
 def test_predictability_is_named_the_durable_signal():
     """The note must point to predictability (drift→0), not the multiplier, as
-    the signal that matters."""
+    the signal that matters (PT-BR rendered output: previsibilidade)."""
     text = DASHBOARD.read_text().lower()
-    assert "predictability" in text
+    assert "previsibilidade" in text
     assert "drift" in text and "converg" in text
 
 

--- a/tests/test_bcp_integration.py
+++ b/tests/test_bcp_integration.py
@@ -88,7 +88,7 @@ def test_dashboard_bcp_section_is_conditional():
     """The BCP Productivity section must be gated on bcp_recorded existing —
     stories without BCP must not trigger it."""
     text = DASHBOARD.read_text()
-    assert "📊 BCP Productivity" in text
+    assert "📊 Produtividade BCP" in text
     assert "CONDITIONAL" in text and "bcp_recorded" in text
 
 

--- a/tests/test_invert_speedometer.py
+++ b/tests/test_invert_speedometer.py
@@ -54,8 +54,8 @@ def test_predictability_leads_table_before_leverage():
     """Ordering invariant: in General Statistics the Predictability row must
     appear BEFORE the leverage row — leverage is no longer the headline."""
     text = DASHBOARD.read_text()
-    pred_idx = text.find("| **Predictability**")
-    lev_idx = text.find("| AI Leverage (vs PLAN")
+    pred_idx = text.find("| **Previsibilidade**")
+    lev_idx = text.find("| AI Leverage (vs PLANO")
     assert pred_idx != -1 and lev_idx != -1, "both rows must be present"
     assert pred_idx < lev_idx, "Predictability must lead; leverage comes after"
 
@@ -64,8 +64,8 @@ def test_leverage_demoted_to_context():
     """Leverage must be labelled vs PLAN and explicitly marked as context, not
     a target — and the old 'Avg AI Leverage' headline row must be gone."""
     text = DASHBOARD.read_text()
-    assert "AI Leverage (vs PLAN" in text
-    assert "context, not a target" in text
+    assert "AI Leverage (vs PLANO" in text
+    assert "contexto, não meta" in text
     assert "| Avg AI Leverage         | {avg}x             |" not in text, (
         "the pre-v0.6 leverage headline row must be replaced"
     )
@@ -129,7 +129,7 @@ def test_regime_falls_back_to_global_method():
 def test_regime_labels_leverage_vs_plan_regime():
     """The leverage context line must carry the regime: 'vs PLAN ({regime})'."""
     text = DASHBOARD.read_text()
-    assert "vs PLAN, {dominant_regime}" in text or "vs PLAN ({dominant_regime})" in text
+    assert "vs PLANO, {dominant_regime}" in text or "vs PLANO ({dominant_regime})" in text
 
 
 def test_regime_read_is_zero_write_coupled():
@@ -198,7 +198,7 @@ def test_leverage_thresholds_marked_legacy():
 def test_leverage_labeled_vs_plan_in_cards_and_tables():
     """Every leverage display reads 'vs PLAN', never 'vs human' as a target."""
     done = TRACK_DONE.read_text()
-    assert "AI Leverage: {leverage_ratio}x (vs PLAN" in done
+    assert "AI Leverage: {leverage_ratio}x (vs PLAN" in done  # track-done card stays EN
     dash = DASHBOARD.read_text()
-    assert "Avg Leverage (vs PLAN)" in dash
-    assert "Leverage (vs PLAN) | Quality" in dash
+    assert "Leverage médio (vs PLANO)" in dash
+    assert "Leverage (vs PLANO) | Qualidade" in dash


### PR DESCRIPTION
## Dashboard em PT-BR

Traduz a **saída renderizada** do dashboard pra português do Brasil, **mantendo termos e jargões** técnicos em inglês (`h/BCP`, `BCP`, `leverage`, `drift`, `micro`/`story`, nomes de campo). Preparação pra v0.8 já nascer PT-BR.

### O que mudou

- **`skills/bmad-pulse-dashboard/workflow.md`** — o bloco renderizado (`dashboard.md`) e o card do terminal traduzidos: títulos de seção (`Estatísticas Gerais`, `Produtividade BCP`, `Monitor de drift de estimativa`, …), cabeçalhos de tabela, labels, mensagens e notas. O multiplicador lê-se **"vs PLANO"**. A **lógica de agregação interna** (Step 1: definições de `predictability_score`, `cohort_drift`, etc.) **fica em inglês** — é interna, não é "o dashboard".
- **Behavior restriction** esclarecida: o template é **PT-BR por default**; se `communication_language` for outro idioma, o agente localiza os labels (jargão e `{placeholders}` sempre inalterados).
- **`examples/dashboards/mature-bmad-team.md`** — exemplo traduzido (sample histórico da era leverage, pré-v0.5; estrutura preservada, sem fabricar dados v0.6/v0.7).
- **Testes** invariantes que casavam strings renderizadas em inglês atualizados pros equivalentes PT-BR (`test_invert_speedometer`, `test_anti_goodhart`, `test_bcp_integration`, `test_action_alert`).

### Escopo

- **Só a saída renderizada** do dashboard. Lógica interna fica EN.
- Cards do `track-start`/`track-done` **não** foram traduzidos (decisão: só "o dashboard"). Posso estender se quiser.
- `README.en.md` mantém o exemplo em inglês (doc inglês; usuário en seta `communication_language=en`).

### Testes

**Suíte completa: 192 verde.** Nenhum teste removido — os que casavam strings EN renderizadas foram atualizados pros equivalentes PT-BR (mesmos invariantes, idioma novo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
