### PR TITLE
feat(config): PULSE toml-first — resolve_config.py + fallback yaml (#73)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -5,6 +5,44 @@ skip to the version you are migrating from.
 
 ---
 
+## toml-first config — `config.toml` with per-key `config.yaml` fallback (issue #73)
+
+**Who this affects:** installs on post-#2285 BMAD, where the canonical config is
+`_bmad/config.toml` (resolved by `_bmad/scripts/resolve_config.py` across four
+layers) and `_bmad/config.yaml` is legacy. Before this change PULSE read/wrote
+**only** the yaml, so it never saw `config.toml` nor the `custom/config.toml`
+overrides — a split-brain where the values diverged and PULSE stayed on the
+legacy file.
+
+**What changed:**
+
+- **Consumers resolve toml-first.** Every workflow/agent now runs
+  `resolve_config.py --key modules.pulse`, reads `pulse_*` from the resolved
+  toml, **falls back per key** to the legacy `pulse:` section of `config.yaml`,
+  and uses the `module.yaml` default only when neither has the key.
+- **Setup writes toml.** `merge-config.py` writes the module section to
+  `_bmad/custom/config.toml` under `[modules.pulse]` (the layer that wins over
+  installer defaults), preserving that file's comments and other sections. It
+  no longer writes the `pulse:` section into `config.yaml` and **strips** a
+  stale one on run.
+
+**⚠ Caveat crítico (pareamento obrigatório).** The `[modules.pulse]` in
+`config.toml` on a post-#2285 install carries the *install defaults*
+(`pulse_dev_categories = "standard_4"`, `pulse_estimation_method = "hours"`),
+which do **not** match a team using a custom taxonomy (e.g.
+`frontend, backend, fullstack, mobile, security`) or `bcp`. If PULSE goes
+toml-first **without** the team's real values pinned in `custom/config.toml`,
+it silently regresses to the install defaults and loses the custom taxonomy.
+
+**How to migrate (re-run setup):** re-running `bmad-pulse-setup` is the
+migration. It reads the current effective values (resolved toml, then the legacy
+`pulse:` in `config.yaml`) and offers them as the prompt defaults; accepting the
+defaults pins the team's answers into `custom/config.toml [modules.pulse]` and
+strips the legacy yaml section. Verify `pulse_dev_categories` and
+`pulse_estimation_method` in `custom/config.toml` after migrating.
+
+---
+
 ## Upgrading over an existing install — automatic self-heal
 
 This applies to **every** PULSE upgrade, not a specific version.

--- a/skills/bmad-agent-pulse/SKILL.md
+++ b/skills/bmad-agent-pulse/SKILL.md
@@ -46,7 +46,7 @@ Treat every entry in `{agent.persistent_facts}` as foundational context you carr
 
 ### Step 5: Load Config
 
-Load config from `{project-root}/_bmad/config.yaml`, section `pulse`, and resolve:
+Resolve the PULSE configuration **toml-first** (issue #73): run `python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key modules.pulse --key core` and read `pulse_*` from the `modules.pulse` table and core keys from `core`. **Per-key fallback** to the legacy `pulse:` section (or root) of `{project-root}/_bmad/config.yaml` for any key absent from the resolved toml (yaml is the lowest-priority layer); **default last** from `module.yaml`. If `resolve_config.py` is unavailable (pre-#2285 install), read `config.yaml` directly as before. Then resolve:
 
 - Use `{user_name}` for greeting (falls back to `{project-root}/_bmad/config.user.yaml`)
 - Use `{communication_language}` for all communications

--- a/skills/bmad-pulse-dashboard/workflow.md
+++ b/skills/bmad-pulse-dashboard/workflow.md
@@ -53,7 +53,15 @@ Load the PULSE configuration as described in INITIALIZATION below, then execute 
 
 ### Configuration Loading
 
-Load the `pulse` section from `{main_config}` and resolve all module variables:
+Resolve the PULSE configuration **toml-first** (issue #73):
+
+1. Run `python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key modules.pulse --key core` and read `pulse_*` from the `modules.pulse` table and core keys (`project_name`/`output_folder`, `communication_language`) from `core`.
+2. **Per-key fallback** — for any key absent from the resolved toml, read it from the legacy `pulse:` section (module keys) or root (core keys) of `{main_config}`; the yaml is the lowest-priority layer, never authoritative over the toml.
+3. **Default last** — if neither has the key, use the `module.yaml` default.
+
+If `resolve_config.py` is unavailable (pre-#2285 install), read `{main_config}` directly as before.
+
+The keys this workflow uses:
 
 - `project_name`, `communication_language`
 - `pulse_data_folder`, `pulse_sprint_status_filename`

--- a/skills/bmad-pulse-setup/SKILL.md
+++ b/skills/bmad-pulse-setup/SKILL.md
@@ -7,13 +7,16 @@ description: Installs and configures the PULSE module in a BMAD project. Use whe
 
 ## Overview
 
-Installs and configures a BMad module into a project. Module identity (name, code, version) comes from `./assets/module.yaml`. Collects user preferences and writes them to three files:
+Installs and configures a BMad module into a project. Module identity (name, code, version) comes from `./assets/module.yaml`. Collects user preferences and writes them to these files:
 
-- **`{project-root}/_bmad/config.yaml`** — shared project config: core settings at root (e.g. `output_folder`, `document_output_language`) plus a section per module with metadata and module-specific values. User-only keys (`user_name`, `communication_language`) are **never** written here.
+- **`{project-root}/_bmad/custom/config.toml`** — the module section `[modules.pulse]` with the `pulse_*` values (issue #73, toml-first). This is the layer `resolve_config.py` reads with higher priority than the installer defaults in `config.toml`, so the team's answers win. Existing comments and other sections in this human-owned file are preserved (tomlkit round-trip).
+- **`{project-root}/_bmad/config.yaml`** — shared project config: core settings at root only (e.g. `output_folder`, `document_output_language`). The legacy `pulse:` module section is **no longer** written here; a stale one is stripped on run (that strip is the yaml→toml migration). User-only keys (`user_name`, `communication_language`) are **never** written here.
 - **`{project-root}/_bmad/config.user.yaml`** — personal settings intended to be gitignored: `user_name`, `communication_language`, and any module variable marked `user_setting: true` in `./assets/module.yaml`. These values live exclusively here.
 - **`{project-root}/_bmad/module-help.csv`** — registers module capabilities for the help system.
 
-Both config scripts use an anti-zombie pattern — existing entries for this module are removed before writing fresh ones, so stale values never persist.
+The config scripts use an anti-zombie pattern — the module's answered keys are overwritten with fresh values on each run, and the stale legacy `pulse:` yaml section is removed, so stale values never persist.
+
+**Migrating an existing yaml install (issue #73):** re-running this setup is the migration path. Before prompting, read the current effective values (via `resolve_config.py --key modules.pulse` and the legacy `pulse:` section of `config.yaml`) and offer them as the prompt defaults, so accepting the defaults carries the team's existing answers into `custom/config.toml` and strips the legacy yaml section.
 
 `{project-root}` is a **literal token** in config values — never substitute it with an actual path. It signals to the consuming LLM that the value is relative to the project root, not the skill root.
 
@@ -68,7 +71,7 @@ Ask the user for values. Show defaults in brackets. Present all values together 
 
 **Core config** (only if no core keys exist yet): `user_name` (default: BMad), `communication_language` and `document_output_language` (default: English — ask as a single language question, both keys get the same answer), `output_folder` (default: `{project-root}/_bmad-output`). Of these, `user_name` and `communication_language` are written exclusively to `config.user.yaml`. The rest go to `config.yaml` at root and are shared across all modules.
 
-**Module config**: Read each variable in `./assets/module.yaml` that has a `prompt` field. Ask using that prompt with its default value (or legacy value if available).
+**Module config**: Read each variable in `./assets/module.yaml` that has a `prompt` field. Ask using that prompt, pre-filling the default with the **current effective value** when re-running on an existing install: prefer the resolved `modules.pulse` value (`resolve_config.py --key modules.pulse`), then the legacy `pulse:` value in `config.yaml`, then any legacy per-module value, then the `module.yaml` default. This is what carries an existing team's answers into `custom/config.toml` on the migration re-run.
 
 **Validation rules:**
 - If `pulse_estimation_method` = `story_points` and `pulse_story_point_hours_factor` has not been set, warn before continuing
@@ -83,6 +86,8 @@ Write a temp JSON file with the collected answers structured as `{"core": {...},
 python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file} --legacy-dir "{project-root}/_bmad"
 python3 ./scripts/merge-help-csv.py --target "{project-root}/_bmad/module-help.csv" --source ./assets/module-help.csv --legacy-dir "{project-root}/_bmad" --module-code pulse
 ```
+
+`merge-config.py` writes the `[modules.pulse]` section to `{project-root}/_bmad/custom/config.toml` (derived from the `--config-path` directory; override with `--custom-config-path`), writes core keys to `config.yaml`, strips any legacy `pulse:` yaml section, and writes user settings to `config.user.yaml`. Check `custom_config_path` and `module_keys` in the output.
 
 Both scripts output JSON to stdout with results. If either exits non-zero, surface the error and stop. The scripts automatically read legacy config values as fallback defaults, then delete the legacy files after a successful merge. Check `legacy_configs_deleted` and `legacy_csvs_deleted` in the output to confirm cleanup.
 

--- a/skills/bmad-pulse-setup/scripts/merge-config.py
+++ b/skills/bmad-pulse-setup/scripts/merge-config.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
 # /// script
-# requires-python = ">=3.9"
-# dependencies = ["pyyaml"]
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml", "tomlkit"]
 # ///
-"""Merge module configuration into shared _bmad/config.yaml and config.user.yaml.
+"""Merge module configuration into _bmad/custom/config.toml and config.user.yaml.
 
-Reads a module.yaml definition and a JSON answers file, then writes or updates
-the shared config.yaml (core values at root + module section) and config.user.yaml
-(user_name, communication_language, plus any module variable with user_setting: true).
-Uses an anti-zombie pattern for the module section in config.yaml.
+Reads a module.yaml definition and a JSON answers file, then:
+
+- writes the module variable values (``pulse_*``) into
+  ``_bmad/custom/config.toml`` under ``[modules.<code>]`` — the layer
+  ``resolve_config.py`` reads with higher priority than the installer defaults
+  in ``config.toml`` (issue #73, toml-first). Existing comments and other
+  sections in that human-owned file are preserved (tomlkit round-trip);
+- writes core values (``output_folder`` etc.) at the root of ``config.yaml``;
+- writes ``config.user.yaml`` (``user_name``, ``communication_language``, plus
+  any module variable with ``user_setting: true``).
+
+The legacy ``<code>:`` module section is **no longer** written to
+``config.yaml`` and any stale one there is stripped on run — that strip is the
+yaml→toml migration path (re-run setup to migrate an existing install).
 
 Legacy migration: when --legacy-dir is provided, reads old per-module config files
 from {legacy-dir}/{module-code}/config.yaml and {legacy-dir}/core/config.yaml.
@@ -30,6 +40,12 @@ except ImportError:
     print("Error: pyyaml is required (PEP 723 dependency)", file=sys.stderr)
     sys.exit(2)
 
+try:
+    import tomlkit
+except ImportError:
+    print("Error: tomlkit is required (PEP 723 dependency)", file=sys.stderr)
+    sys.exit(2)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -38,7 +54,13 @@ def parse_args():
     parser.add_argument(
         "--config-path",
         required=True,
-        help="Path to the target _bmad/config.yaml file",
+        help="Path to the target _bmad/config.yaml file (core keys only)",
+    )
+    parser.add_argument(
+        "--custom-config-path",
+        help="Path to the target _bmad/custom/config.toml file where the module "
+        "section [modules.<code>] is written. Defaults to "
+        "{config-path dir}/custom/config.toml.",
     )
     parser.add_argument(
         "--module-yaml",
@@ -179,18 +201,6 @@ def cleanup_legacy_configs(
     return deleted
 
 
-def extract_module_metadata(module_yaml: dict) -> dict:
-    """Extract non-variable metadata fields from module.yaml."""
-    meta = {}
-    for k in ("name", "description"):
-        if k in module_yaml:
-            meta[k] = module_yaml[k]
-    meta["version"] = module_yaml.get("module_version")  # null if absent
-    if "default_selected" in module_yaml:
-        meta["default_selected"] = module_yaml["default_selected"]
-    return meta
-
-
 def apply_result_templates(
     module_yaml: dict, module_answers: dict, verbose: bool = False
 ) -> dict:
@@ -268,31 +278,93 @@ def merge_config(
                 print(f"Writing core config at root: {list(shared_core.keys())}", file=sys.stderr)
             config.update(shared_core)
 
-    # Anti-zombie: remove existing module section
+    # Toml-first (issue #73): the module section is written to
+    # custom/config.toml (see write_module_toml), NOT here. Strip any stale
+    # legacy section from config.yaml so the yaml stops shadowing the resolved
+    # toml — this strip is the yaml→toml migration when an existing install
+    # re-runs setup.
     if module_code in config:
         if verbose:
             print(
-                f"Removing existing '{module_code}' section (anti-zombie)",
+                f"Stripping legacy '{module_code}:' section from config.yaml "
+                f"(now written to custom/config.toml)",
                 file=sys.stderr,
             )
         del config[module_code]
 
-    # Build module section: metadata + variable values
-    module_section = extract_module_metadata(module_yaml)
-    module_answers = apply_result_templates(
-        module_yaml, answers.get("module", {}), verbose
-    )
-    module_section.update(module_answers)
+    return config
+
+
+def coerce_toml_scalar(value):
+    """Coerce a config value to the module.yaml string contract.
+
+    Every ``pulse_*`` value is a string by design (module.yaml uses
+    ``result: '{value}'`` and string-valued single-selects). Booleans only
+    appear via the YAML 1.1 unquoted ``yes``/``no`` footgun when values are
+    read back from config.yaml — map them to the ``yes``/``no`` strings the
+    consumers expect. Everything else is stringified.
+    """
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value)
+
+
+def build_module_values(module_yaml: dict, answers: dict, verbose: bool = False) -> dict:
+    """Return the module variable values to pin, result-templated and coerced.
+
+    Metadata (name/description/version) is intentionally excluded — consumers
+    resolve those from module.yaml, not from config. Only the answered module
+    variables are written to [modules.<code>].
+    """
+    module_answers = apply_result_templates(module_yaml, answers.get("module", {}), verbose)
+    return {key: coerce_toml_scalar(value) for key, value in module_answers.items()}
+
+
+def write_module_toml(
+    custom_config_path: str,
+    module_code: str,
+    module_values: dict,
+    verbose: bool = False,
+) -> list:
+    """Upsert module values into [modules.<code>] of custom/config.toml.
+
+    Preserves existing comments and other sections (tomlkit round-trip).
+    Answered keys are overwritten (setup reflects the user's fresh intent);
+    any human-authored key not in this run is left untouched.
+
+    Returns the list of keys written.
+    """
+    path = Path(custom_config_path)
+
+    if path.exists():
+        doc = tomlkit.parse(path.read_text(encoding="utf-8"))
+    else:
+        doc = tomlkit.document()
+
+    modules = doc.get("modules")
+    if modules is None:
+        modules = tomlkit.table(is_super_table=True)
+        doc["modules"] = modules
+
+    module_table = modules.get(module_code)
+    if module_table is None:
+        module_table = tomlkit.table()
+        modules[module_code] = module_table
+
+    for key, value in module_values.items():
+        module_table[key] = value
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(tomlkit.dumps(doc), encoding="utf-8")
 
     if verbose:
         print(
-            f"Writing '{module_code}' section with keys: {list(module_section.keys())}",
+            f"Wrote [modules.{module_code}] to {path} "
+            f"with keys: {list(module_values.keys())}",
             file=sys.stderr,
         )
 
-    config[module_code] = module_section
-
-    return config
+    return list(module_values.keys())
 
 
 # Core keys that are always written to config.user.yaml
@@ -369,7 +441,18 @@ def main():
             if args.verbose:
                 print("Applied legacy values as fallback defaults", file=sys.stderr)
 
-    # Merge and write config.yaml
+    module_code = module_yaml["code"]
+
+    # Write the module section to custom/config.toml (toml-first, issue #73).
+    custom_config_path = args.custom_config_path or str(
+        Path(args.config_path).parent / "custom" / "config.toml"
+    )
+    module_values = build_module_values(module_yaml, answers, args.verbose)
+    module_keys = write_module_toml(
+        custom_config_path, module_code, module_values, args.verbose
+    )
+
+    # Merge and write config.yaml (core keys only; module section stripped)
     updated_config = merge_config(existing_config, module_yaml, answers, args.verbose)
     write_config(updated_config, args.config_path, args.verbose)
 
@@ -389,14 +472,14 @@ def main():
         )
 
     # Output result summary as JSON
-    module_code = module_yaml["code"]
     result = {
         "status": "success",
         "config_path": str(Path(args.config_path).resolve()),
+        "custom_config_path": str(Path(custom_config_path).resolve()),
         "user_config_path": str(Path(args.user_config_path).resolve()),
         "module_code": module_code,
         "core_updated": bool(answers.get("core")),
-        "module_keys": list(updated_config.get(module_code, {}).keys()),
+        "module_keys": module_keys,
         "user_keys": list(user_settings.keys()),
         "legacy_configs_found": legacy_files_found,
         "legacy_configs_deleted": legacy_deleted,

--- a/skills/bmad-pulse-track-backfill/workflow.md
+++ b/skills/bmad-pulse-track-backfill/workflow.md
@@ -57,7 +57,15 @@ Load the PULSE configuration as described in INITIALIZATION below, then execute 
 
 ### Configuration Loading
 
-Load the `pulse` section from `{main_config}` and resolve module variables:
+Resolve the PULSE configuration **toml-first** (issue #73):
+
+1. Run `python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key modules.pulse --key core` and read `pulse_*` from the `modules.pulse` table and core keys (`output_folder`, `user_name`, `communication_language`) from `core`.
+2. **Per-key fallback** — for any key absent from the resolved toml, read it from the legacy `pulse:` section (module keys) or root (core keys) of `{main_config}`; the yaml is the lowest-priority layer, never authoritative over the toml.
+3. **Default last** — if neither has the key, use the `module.yaml` default.
+
+If `resolve_config.py` is unavailable (pre-#2285 install), read `{main_config}` directly as before.
+
+The keys this workflow uses:
 
 - `output_folder`, `user_name`, `communication_language`
 - `pulse_data_folder`, `pulse_dashboard_folder`

--- a/skills/bmad-pulse-track-done/workflow.md
+++ b/skills/bmad-pulse-track-done/workflow.md
@@ -53,7 +53,15 @@ Load the PULSE configuration as described in INITIALIZATION below, then execute 
 
 ### Configuration Loading
 
-Load the config from the `pulse` section of `{main_config}` and resolve all module variables from that section:
+Resolve the PULSE configuration **toml-first** (issue #73):
+
+1. Run `python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key modules.pulse --key core` and read `pulse_*` from the `modules.pulse` table and core keys (`output_folder`, `user_name`, `communication_language`) from `core`.
+2. **Per-key fallback** — for any key absent from the resolved toml, read it from the legacy `pulse:` section (module keys) or root (core keys) of `{main_config}`; the yaml is the lowest-priority layer, never authoritative over the toml.
+3. **Default last** — if neither has the key, use the `module.yaml` default.
+
+If `resolve_config.py` is unavailable (pre-#2285 install), read `{main_config}` directly as before.
+
+The keys this workflow uses:
 
 - `output_folder`, `user_name`, `communication_language`
 - `pulse_data_folder`, `pulse_dashboard_folder`

--- a/skills/bmad-pulse-track-start/workflow.md
+++ b/skills/bmad-pulse-track-start/workflow.md
@@ -53,7 +53,15 @@ Load the PULSE configuration as described in INITIALIZATION below, then execute 
 
 ### Configuration Loading
 
-Load the `pulse` section from `{main_config}` and resolve module variables:
+Resolve the PULSE configuration **toml-first** (issue #73):
+
+1. Run `python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key modules.pulse --key core` and read `pulse_*` from the `modules.pulse` table and core keys (`output_folder`, `user_name`, `communication_language`) from `core`.
+2. **Per-key fallback** — for any key absent from the resolved toml, read it from the legacy `pulse:` section (module keys) or root (core keys) of `{main_config}`; the yaml is the lowest-priority layer, never authoritative over the toml.
+3. **Default last** — if neither has the key, use the `module.yaml` default.
+
+If `resolve_config.py` is unavailable (pre-#2285 install), read `{main_config}` directly as before.
+
+The keys this workflow uses:
 
 - `output_folder`, `user_name`, `communication_language`
 - `pulse_estimation_method` — `hours` / `story_points` / `tshirt` / `bcp`

--- a/tests/test_toml_first_config.py
+++ b/tests/test_toml_first_config.py
@@ -1,0 +1,58 @@
+"""Issue #73: every PULSE config consumer must resolve toml-first.
+
+The consumers are markdown workflows/agents (the LLM reads config), so these
+are structural assertions over their prose: each must invoke the BMAD core
+``resolve_config.py`` for ``modules.pulse``, and document the per-key yaml
+fallback and the default-last precedence.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parents[1]
+
+CONSUMERS = [
+    "skills/bmad-pulse-track-start/workflow.md",
+    "skills/bmad-pulse-track-done/workflow.md",
+    "skills/bmad-pulse-track-backfill/workflow.md",
+    "skills/bmad-pulse-dashboard/workflow.md",
+    "skills/bmad-agent-pulse/SKILL.md",
+]
+
+
+@pytest.mark.parametrize("rel", CONSUMERS)
+def test_consumer_invokes_resolve_config_for_modules_pulse(rel: str):
+    text = (REPO / rel).read_text(encoding="utf-8")
+    assert "resolve_config.py" in text, f"{rel} must resolve config toml-first"
+    assert "--key modules.pulse" in text, f"{rel} must read the modules.pulse table"
+
+
+@pytest.mark.parametrize("rel", CONSUMERS)
+def test_consumer_documents_yaml_fallback_and_default_last(rel: str):
+    text = (REPO / rel).read_text(encoding="utf-8").lower()
+    assert "fallback" in text, f"{rel} must document the per-key yaml fallback"
+    assert "config.yaml" in text, f"{rel} must name config.yaml as the fallback layer"
+    assert "default" in text, f"{rel} must document the module.yaml default as last resort"
+
+
+@pytest.mark.parametrize("rel", CONSUMERS)
+def test_consumer_yaml_is_not_authoritative(rel: str):
+    """The old prose loaded the pulse section from config.yaml as the source of
+    truth. That phrasing must be gone — toml is authoritative now."""
+    text = (REPO / rel).read_text(encoding="utf-8")
+    assert "Load the `pulse` section from `{main_config}`" not in text
+    assert "Load config from `{project-root}/_bmad/config.yaml`, section `pulse`" not in text
+
+
+def test_merge_config_writes_custom_toml_not_yaml_module_section():
+    """The setup write-path must target custom/config.toml for the module
+    section and must not re-introduce a config.yaml module write."""
+    script = (REPO / "skills/bmad-pulse-setup/scripts/merge-config.py").read_text(
+        encoding="utf-8"
+    )
+    assert "custom" in script and "config.toml" in script
+    assert "write_module_toml" in script
+    # anti-zombie strip of the legacy yaml module section
+    assert "del config[module_code]" in script

--- a/tests/unit/test_merge_config_toml.py
+++ b/tests/unit/test_merge_config_toml.py
@@ -1,0 +1,167 @@
+"""Unit tests for the toml-first write path of merge-config.py.
+
+Issue #73: PULSE is toml-first. The setup write-path (merge-config.py) must
+write the module answers into ``_bmad/custom/config.toml`` under
+``[modules.pulse]`` — the layer ``resolve_config.py`` reads with higher
+priority than the installer defaults in ``config.toml`` — and must NOT write
+the legacy ``pulse:`` section into ``config.yaml`` anymore (it strips a stale
+one on re-run, which is the migration path). Core keys stay in ``config.yaml``.
+
+Matrix required by the acceptance criteria: fresh toml write, yaml→toml
+migration (strip), both (preserve human custom content), none (core-only).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).parents[2]
+SCRIPT = REPO / "skills/bmad-pulse-setup/scripts/merge-config.py"
+MODULE_YAML = REPO / "skills/bmad-pulse-setup/assets/module.yaml"
+
+
+def run(project_root: Path, answers: dict) -> subprocess.CompletedProcess[str]:
+    answers_file = project_root / "answers.json"
+    answers_file.write_text(json.dumps(answers), encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config-path",
+            str(project_root / "_bmad/config.yaml"),
+            "--user-config-path",
+            str(project_root / "_bmad/config.user.yaml"),
+            "--module-yaml",
+            str(MODULE_YAML),
+            "--answers",
+            str(answers_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def read_custom_pulse(project_root: Path) -> dict:
+    path = project_root / "_bmad/custom/config.toml"
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return data.get("modules", {}).get("pulse", {})
+
+
+def read_yaml(project_root: Path) -> dict:
+    path = project_root / "_bmad/config.yaml"
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+# The custom taxonomy that must survive the cutover (caveat crítico da issue).
+SIP_MODULE_ANSWERS = {
+    "module": {
+        "pulse_estimation_method": "bcp",
+        "pulse_dev_categories": "frontend, backend, fullstack, mobile, security",
+        "pulse_field_estimated_hours": "estimated_hours",
+        "pulse_min_stories_for_trend": "3",
+        "pulse_include_trend_chart": "yes",
+    }
+}
+
+
+# --- fresh: writes toml, never a pulse: section in config.yaml ---
+
+def test_fresh_writes_pulse_to_custom_toml(tmp_path: Path):
+    result = run(tmp_path, SIP_MODULE_ANSWERS)
+    assert result.returncode == 0, result.stderr
+
+    pinned = read_custom_pulse(tmp_path)
+    assert pinned["pulse_estimation_method"] == "bcp"
+    assert pinned["pulse_dev_categories"] == "frontend, backend, fullstack, mobile, security"
+
+
+def test_fresh_never_writes_pulse_section_to_yaml(tmp_path: Path):
+    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    assert "pulse" not in read_yaml(tmp_path)
+
+
+def test_metadata_not_pinned_only_pulse_values(tmp_path: Path):
+    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    pinned = read_custom_pulse(tmp_path)
+    for meta in ("name", "description", "version", "default_selected"):
+        assert meta not in pinned
+    assert all(k.startswith("pulse_") for k in pinned)
+
+
+def test_values_are_strings(tmp_path: Path):
+    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    pinned = read_custom_pulse(tmp_path)
+    assert pinned["pulse_min_stories_for_trend"] == "3"
+    assert pinned["pulse_include_trend_chart"] == "yes"
+    assert all(isinstance(v, str) for v in pinned.values())
+
+
+# --- migration: an existing legacy pulse: in config.yaml is stripped ---
+
+def test_migration_strips_legacy_yaml_pulse_section(tmp_path: Path):
+    (tmp_path / "_bmad").mkdir(parents=True)
+    (tmp_path / "_bmad/config.yaml").write_text(
+        "output_folder: '{project-root}/_bmad-output'\n"
+        "pulse:\n"
+        "  name: PULSE\n"
+        "  pulse_estimation_method: hours\n"
+        "  pulse_dev_categories: standard_4\n",
+        encoding="utf-8",
+    )
+    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+
+    cfg = read_yaml(tmp_path)
+    assert "pulse" not in cfg  # legacy section removed
+    assert cfg.get("output_folder") == "{project-root}/_bmad-output"  # core preserved
+    assert read_custom_pulse(tmp_path)["pulse_estimation_method"] == "bcp"
+
+
+# --- both: existing custom/config.toml content + comments preserved ---
+
+def test_preserves_existing_custom_toml_content(tmp_path: Path):
+    custom = tmp_path / "_bmad/custom"
+    custom.mkdir(parents=True)
+    (custom / "config.toml").write_text(
+        "# human-owned team config\n"
+        "[core]\n"
+        'user_name = "Ada"\n\n'
+        "[modules.pulse]\n"
+        'pulse_levi_verbosity = "verbose"\n',
+        encoding="utf-8",
+    )
+    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+
+    text = (custom / "config.toml").read_text(encoding="utf-8")
+    assert "# human-owned team config" in text  # comment preserved
+
+    with (custom / "config.toml").open("rb") as f:
+        data = tomllib.load(f)
+    assert data["core"]["user_name"] == "Ada"  # other section preserved
+    # human-only key under [modules.pulse] preserved, answered keys upserted
+    assert data["modules"]["pulse"]["pulse_levi_verbosity"] == "verbose"
+    assert data["modules"]["pulse"]["pulse_estimation_method"] == "bcp"
+
+
+def test_rerun_overwrites_managed_keys(tmp_path: Path):
+    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    changed = {"module": dict(SIP_MODULE_ANSWERS["module"], pulse_estimation_method="hours")}
+    assert run(tmp_path, changed).returncode == 0
+    assert read_custom_pulse(tmp_path)["pulse_estimation_method"] == "hours"
+
+
+# --- none: core-only answers still land in config.yaml, no toml module noise ---
+
+def test_core_keys_still_written_to_yaml(tmp_path: Path):
+    answers = {"core": {"output_folder": "custom-out"}, "module": SIP_MODULE_ANSWERS["module"]}
+    assert run(tmp_path, answers).returncode == 0
+    cfg = read_yaml(tmp_path)
+    assert cfg["output_folder"] == "custom-out"
+    assert "pulse" not in cfg

--- a/tests/unit/test_merge_config_toml.py
+++ b/tests/unit/test_merge_config_toml.py
@@ -61,7 +61,7 @@ def read_yaml(project_root: Path) -> dict:
 
 
 # The custom taxonomy that must survive the cutover (caveat crítico da issue).
-SIP_MODULE_ANSWERS = {
+CUSTOM_MODULE_ANSWERS = {
     "module": {
         "pulse_estimation_method": "bcp",
         "pulse_dev_categories": "frontend, backend, fullstack, mobile, security",
@@ -75,7 +75,7 @@ SIP_MODULE_ANSWERS = {
 # --- fresh: writes toml, never a pulse: section in config.yaml ---
 
 def test_fresh_writes_pulse_to_custom_toml(tmp_path: Path):
-    result = run(tmp_path, SIP_MODULE_ANSWERS)
+    result = run(tmp_path, CUSTOM_MODULE_ANSWERS)
     assert result.returncode == 0, result.stderr
 
     pinned = read_custom_pulse(tmp_path)
@@ -84,12 +84,12 @@ def test_fresh_writes_pulse_to_custom_toml(tmp_path: Path):
 
 
 def test_fresh_never_writes_pulse_section_to_yaml(tmp_path: Path):
-    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    assert run(tmp_path, CUSTOM_MODULE_ANSWERS).returncode == 0
     assert "pulse" not in read_yaml(tmp_path)
 
 
 def test_metadata_not_pinned_only_pulse_values(tmp_path: Path):
-    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    assert run(tmp_path, CUSTOM_MODULE_ANSWERS).returncode == 0
     pinned = read_custom_pulse(tmp_path)
     for meta in ("name", "description", "version", "default_selected"):
         assert meta not in pinned
@@ -97,7 +97,7 @@ def test_metadata_not_pinned_only_pulse_values(tmp_path: Path):
 
 
 def test_values_are_strings(tmp_path: Path):
-    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    assert run(tmp_path, CUSTOM_MODULE_ANSWERS).returncode == 0
     pinned = read_custom_pulse(tmp_path)
     assert pinned["pulse_min_stories_for_trend"] == "3"
     assert pinned["pulse_include_trend_chart"] == "yes"
@@ -116,7 +116,7 @@ def test_migration_strips_legacy_yaml_pulse_section(tmp_path: Path):
         "  pulse_dev_categories: standard_4\n",
         encoding="utf-8",
     )
-    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    assert run(tmp_path, CUSTOM_MODULE_ANSWERS).returncode == 0
 
     cfg = read_yaml(tmp_path)
     assert "pulse" not in cfg  # legacy section removed
@@ -137,7 +137,7 @@ def test_preserves_existing_custom_toml_content(tmp_path: Path):
         'pulse_levi_verbosity = "verbose"\n',
         encoding="utf-8",
     )
-    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
+    assert run(tmp_path, CUSTOM_MODULE_ANSWERS).returncode == 0
 
     text = (custom / "config.toml").read_text(encoding="utf-8")
     assert "# human-owned team config" in text  # comment preserved
@@ -151,8 +151,8 @@ def test_preserves_existing_custom_toml_content(tmp_path: Path):
 
 
 def test_rerun_overwrites_managed_keys(tmp_path: Path):
-    assert run(tmp_path, SIP_MODULE_ANSWERS).returncode == 0
-    changed = {"module": dict(SIP_MODULE_ANSWERS["module"], pulse_estimation_method="hours")}
+    assert run(tmp_path, CUSTOM_MODULE_ANSWERS).returncode == 0
+    changed = {"module": dict(CUSTOM_MODULE_ANSWERS["module"], pulse_estimation_method="hours")}
     assert run(tmp_path, changed).returncode == 0
     assert read_custom_pulse(tmp_path)["pulse_estimation_method"] == "hours"
 
@@ -160,7 +160,7 @@ def test_rerun_overwrites_managed_keys(tmp_path: Path):
 # --- none: core-only answers still land in config.yaml, no toml module noise ---
 
 def test_core_keys_still_written_to_yaml(tmp_path: Path):
-    answers = {"core": {"output_folder": "custom-out"}, "module": SIP_MODULE_ANSWERS["module"]}
+    answers = {"core": {"output_folder": "custom-out"}, "module": CUSTOM_MODULE_ANSWERS["module"]}
     assert run(tmp_path, answers).returncode == 0
     cfg = read_yaml(tmp_path)
     assert cfg["output_folder"] == "custom-out"


### PR DESCRIPTION
Fecha #73. Par no BCP (repo separado): nidelson/bmad-module-bcp#36.

## Problema
Pós-#2285 o config canônico é `_bmad/config.toml` (resolvido pelo `resolve_config.py` do BMAD core, merge de 4 camadas) e o `config.yaml` é legado. O PULSE lia/escrevia **só** o yaml — não enxergava `config.toml` nem os overrides de `custom/config.toml`. Split-brain: os valores divergiam e o PULSE ficava preso no legado.

## Solução (rota enxuta — sem "resolver do resolver")
O BMAD core já tem o `resolve_config.py`. Não replicamos merge nenhum.

- **Consumidores toml-first.** Os 4 workflows (`track-start`, `track-done`, `track-backfill`, `dashboard`) + o agent `Levi` passam a rodar `resolve_config.py --key modules.pulse`, com **fallback por chave** pro `pulse:` do `config.yaml` (camada de menor prioridade) e **default** do `module.yaml` por último.
- **Write-path grava toml.** `merge-config.py` grava a seção do módulo em `_bmad/custom/config.toml` sob `[modules.pulse]` — a camada que vence os defaults de install — preservando comentários e outras seções do arquivo humano (tomlkit). **Não grava mais** `pulse:` no `config.yaml` e faz **strip** de uma seção legada (a migração é rerodar o setup, que pré-preenche os prompts com os valores atuais).

## Caveat crítico (coberto)
O `[modules.pulse]` do `config.toml` traz os defaults de install (`pulse_dev_categories = "standard_4"`, `pulse_estimation_method = "hours"`), que **não** batem com times de taxonomia custom/`bcp`. A migração via re-run pina os valores reais em `custom/config.toml` **antes** do cutover — sem regressão silenciosa. Doc em `docs/MIGRATION.md`.

## Critérios de aceitação
- [x] PULSE lê `pulse_*` do toml/camadas; fallback por chave pro yaml; defaults por último.
- [x] Overrides de `custom/config.toml` honrados (validado contra o `resolve_config.py` real).
- [x] Valores custom pinados em `custom/config.toml` na migração (re-run do setup).
- [x] Testes atualizados (merge-config + consumidores): fresh/migração/preserva-custom/core-only + estruturais.

## Testes
`249 passed` (+16). Matriz do write toml + estruturais dos consumidores. **Validado end-to-end**: `merge-config` escreve `custom/config.toml`, o `resolve_config.py` real do BMAD core devolve `bcp` + taxonomia custom (custom vence os defaults `hours`/`standard_4`), `config.yaml` sem `pulse:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)